### PR TITLE
Set claim period correctly for any decision

### DIFF
--- a/contracts/core/governance/resolution/Resolvable.sol
+++ b/contracts/core/governance/resolution/Resolvable.sol
@@ -61,10 +61,10 @@ abstract contract Resolvable is Finalization, IResolvable {
     if (decision) {
       claimBeginsFrom = block.timestamp + 24 hours; // solhint-disable-line
       claimExpiresAt = claimBeginsFrom + s.getClaimPeriod();
-
-      s.setUintByKeys(ProtoUtilV1.NS_CLAIM_BEGIN_TS, key, claimBeginsFrom);
-      s.setUintByKeys(ProtoUtilV1.NS_CLAIM_EXPIRY_TS, key, claimExpiresAt);
     }
+
+    s.setUintByKeys(ProtoUtilV1.NS_CLAIM_BEGIN_TS, key, claimBeginsFrom);
+    s.setUintByKeys(ProtoUtilV1.NS_CLAIM_EXPIRY_TS, key, claimExpiresAt);
 
     s.setStatus(key, status);
 


### PR DESCRIPTION
- Resets the `claimBeginsFrom` and `claimExpiresAt` back to zero, if the incident is resolved as false.