### PR TITLE
Refactoring Policy Fee Calculation

### DIFF
--- a/.solcover.js
+++ b/.solcover.js
@@ -1,2 +1,12 @@
 module.exports = {
+  peephole: false,
+  inliner: false,
+  jumpdestRemover: false,
+  orderLiterals: true, 
+  deduplicate: false,
+  cse: false,
+  constantOptimizer: false,
+  yul: false,
+  configureYulOptimizer: true,
+  skipFiles: ['fakes', 'libraries/BokkyPooBahsDateTimeLibrary.sol']
 }

--- a/contracts/core/policy/Policy.sol
+++ b/contracts/core/policy/Policy.sol
@@ -120,6 +120,31 @@ contract Policy is IPolicy, Recoverable {
   }
 
   /**
+   * @dev Gets the cover fee info for the given cover key, duration, and amount
+   * @param key Enter the cover key
+   * @param coverDuration Enter the number of months to cover. Accepted values: 1-3.
+   * @param amountToCover Enter the amount of the stablecoin `liquidityToken` to cover.
+   */
+  function calculatePolicyFee(
+    bytes32 key,
+    uint256 coverDuration,
+    uint256 amountToCover
+  )
+    external
+    view
+    returns (
+      uint256 fee,
+      uint256 utilizationRatio,
+      uint256 totalAvailableLiquidity,
+      uint256 floor,
+      uint256 ceiling,
+      uint256 rate
+    )
+  {
+    return s.calculatePolicyFeeInternal(key, coverDuration, amountToCover);
+  }
+
+  /**
    * @dev Returns the values of the given cover key
    * @param _values[0] The total amount in the cover pool
    * @param _values[1] The total commitment amount

--- a/contracts/core/policy/Policy.sol
+++ b/contracts/core/policy/Policy.sol
@@ -110,32 +110,6 @@ contract Policy is IPolicy, Recoverable {
       uint256 fee,
       uint256 utilizationRatio,
       uint256 totalAvailableLiquidity,
-      uint256 coverRatio,
-      uint256 floor,
-      uint256 ceiling,
-      uint256 rate
-    )
-  {
-    return s.getCoverFeeInfoInternal(key, coverDuration, amountToCover);
-  }
-
-  /**
-   * @dev Gets the cover fee info for the given cover key, duration, and amount
-   * @param key Enter the cover key
-   * @param coverDuration Enter the number of months to cover. Accepted values: 1-3.
-   * @param amountToCover Enter the amount of the stablecoin `liquidityToken` to cover.
-   */
-  function calculatePolicyFee(
-    bytes32 key,
-    uint256 coverDuration,
-    uint256 amountToCover
-  )
-    external
-    view
-    returns (
-      uint256 fee,
-      uint256 utilizationRatio,
-      uint256 totalAvailableLiquidity,
       uint256 floor,
       uint256 ceiling,
       uint256 rate

--- a/contracts/interfaces/IPolicy.sol
+++ b/contracts/interfaces/IPolicy.sol
@@ -39,7 +39,6 @@ interface IPolicy is IMember {
       uint256 fee,
       uint256 utilizationRatio,
       uint256 totalAvailableLiquidity,
-      uint256 coverRatio,
       uint256 floor,
       uint256 ceiling,
       uint256 rate

--- a/contracts/libraries/CoverLibV1.sol
+++ b/contracts/libraries/CoverLibV1.sol
@@ -174,7 +174,7 @@ library CoverLibV1 {
     uint256 stakeWithFee
   ) private view returns (uint256 fee, uint256 minCoverCreationStake) {
     require(info > 0, "Invalid info");
-    (fee, minCoverCreationStake, ) = s.getCoverFee();
+    (fee, minCoverCreationStake, ) = s.getCoverCreationFeeInfo();
 
     uint256 minStake = fee + minCoverCreationStake;
 

--- a/contracts/libraries/CoverUtilV1.sol
+++ b/contracts/libraries/CoverUtilV1.sol
@@ -36,7 +36,7 @@ library CoverUtilV1 {
     return s.getAddressByKeys(ProtoUtilV1.NS_COVER_OWNER, key);
   }
 
-  function getCoverFee(IStore s)
+  function getCoverCreationFeeInfo(IStore s)
     external
     view
     returns (

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "slither:x:save": "slither . --print human-summary,vars-and-auth  > ./.todo/slither.x.log 2>&1",
     "test": "hardhat test ./test/specs/**/**.js",
     "test:all": "hardhat test",
-    "coverage": "hardhat coverage --testfiles \"test/**/*.spec.js\"",
+    "coverage": "npx hardhat clean && hardhat coverage --testfiles \"test/**/*.spec.js\"",
     "stories": "hardhat test ./test/stories/*.js",
     "bdd": "hardhat test ./test/bdd/*.js",
     "story": "npm run stories",

--- a/scripts/upgrade/bond-pool.js
+++ b/scripts/upgrade/bond-pool.js
@@ -1,0 +1,81 @@
+const moment = require('moment')
+const { deployer, fileCache, key } = require('../../util')
+
+const DEPLOYMENT_ID = 6
+const reason = 'Fix Bond Pool (Maximum Amount) Bug'
+const timestamp = moment(new Date()).unix()
+
+const upgradeContract = async () => {
+  const cache = await fileCache.from(DEPLOYMENT_ID)
+  const current = await cache.getContracts()
+
+  const upgrade = {
+    reason,
+    timestamp,
+    deployments: [],
+    transactions: []
+  }
+
+  let libraries = {
+    NTransferUtilV2: current.nTransferUtilV2,
+    PriceLibV1: current.priceLibV1,
+    ProtoUtilV1: current.protoUtilV1,
+    StoreKeyUtil: current.storeKeyUtil,
+    ValidationLibV1: current.validationLibV1
+  }
+
+  console.info(libraries)
+
+  const BondPoolLibV1 = await deployer.deployWithLibraries(null, 'BondPoolLibV1', libraries)
+
+  const newBondPoolLibV1 = BondPoolLibV1.address
+
+  upgrade.deployments.push({
+    hash: BondPoolLibV1.hash,
+    contract: 'BondPoolLibV1',
+    libraries,
+    address: newBondPoolLibV1
+  })
+
+  console.info('BondPoolLibV1 deployed at %s', newBondPoolLibV1)
+
+  libraries = {
+    AccessControlLibV1: current.accessControlLibV1,
+    BondPoolLibV1: newBondPoolLibV1,
+    BaseLibV1: current.baseLibV1,
+    PriceLibV1: current.priceLibV1,
+    ValidationLibV1: current.validationLibV1
+  }
+
+  const BondPool = await deployer.deployWithLibraries(null, 'BondPool', libraries, current.store)
+  const newBondPool = BondPool.address
+
+  upgrade.deployments.push({
+    hash: BondPool.hash,
+    contract: 'BondPool',
+    libraries,
+    address: newBondPool
+  })
+
+  console.info('Bond Pool deployed at %s', newBondPool)
+
+  const args = [key.PROTOCOL.CNS.BOND_POOL, current.bondPool, newBondPool]
+
+  const result = await current.protocolInstance.upgradeContract(...args)
+
+  upgrade.transactions.push({
+    hash: result.hash,
+    contract: 'Protocol',
+    args,
+    address: current.protocol
+  })
+
+  await cache.addUpgrade(upgrade)
+}
+
+upgradeContract()
+  .then(() => process.exit(0))
+  .catch(error => {
+    console.error(error)
+    process.exit(1)
+  })

--- a/test/specs/lifecycle/cover/add-cover.spec.js
+++ b/test/specs/lifecycle/cover/add-cover.spec.js
@@ -31,7 +31,7 @@ describe('Cover: addCover', () => {
     deployed = await deployDependencies()
   })
 
-  it('correctly adds cover when accessed by Whitelisted Cover Creator', async () => {
+  it('correctly adds cover when accessed by whitelisted cover creator', async () => {
     const [owner] = await ethers.getSigners()
 
     deployed.cover.updateCoverCreatorWhitelist(owner.address, true)
@@ -43,7 +43,7 @@ describe('Cover: addCover', () => {
     await deployed.cover.deployVault(coverKey)
   })
 
-  it('reverts when not accessed by Whitelisted Cover Creator', async () => {
+  it('reverts when not accessed by whitelisted cover creator', async () => {
     const [owner, bob] = await ethers.getSigners()
 
     deployed.cover.updateCoverCreatorWhitelist(owner.address, true)

--- a/test/specs/policy/calculate-policy-fee.spec.js
+++ b/test/specs/policy/calculate-policy-fee.spec.js
@@ -42,7 +42,7 @@ const payload = {
 
 const getFee = (amount, duration) => getCoverFee(data, amount, duration, false)
 
-describe('Policy: calculatePolicyFee', () => {
+describe('Policy: getCoverFeeInfo', () => {
   let deployed, coverKey
 
   before(async () => {
@@ -102,7 +102,7 @@ describe('Policy: calculatePolicyFee', () => {
       const expected = helper.formatCurrency(getFee(amount, duration), 4).trim()
 
       it(`must return fee: ${expected} to cover ${helper.formatCurrency(amount, 0)} for ${duration} month(s)`, async () => {
-        const fees = await deployed.policy.calculatePolicyFee(coverKey, duration.toString(), helper.ether(amount))
+        const fees = await deployed.policy.getCoverFeeInfo(coverKey, duration.toString(), helper.ether(amount))
 
         expected.should.equal(helper.formatCurrency(helper.weiToEther(fees), 4))
       })
@@ -110,12 +110,12 @@ describe('Policy: calculatePolicyFee', () => {
   }
 
   it('must revert if zero is specified as the amount to cover', async () => {
-    await deployed.policy.calculatePolicyFee(coverKey, '1', helper.ether(0))
+    await deployed.policy.getCoverFeeInfo(coverKey, '1', helper.ether(0))
       .should.be.rejectedWith('Please enter an amount')
   })
 
   it('must revert if invalid value is specified as the cover duration', async () => {
-    await deployed.policy.calculatePolicyFee(coverKey, '0', helper.ether(10000))
+    await deployed.policy.getCoverFeeInfo(coverKey, '0', helper.ether(10000))
       .should.be.rejectedWith('Invalid duration')
   })
 })

--- a/test/specs/policy/calculate-policy-fee.spec.js
+++ b/test/specs/policy/calculate-policy-fee.spec.js
@@ -1,0 +1,121 @@
+/* eslint-disable no-unused-expressions */
+const { ethers } = require('hardhat')
+const BigNumber = require('bignumber.js')
+const { helper, deployer, key, ipfs } = require('../../../util')
+const { getCoverFee } = require('./util/calculator')
+const composer = require('../../../util/composer')
+const { deployDependencies } = require('./deps')
+const cache = null
+const DAYS = 86400
+const MULTIPLIER = 10_000
+const INCIDENT_SUPPORT_POOL_CAP_RATIO = MULTIPLIER
+
+require('chai')
+  .use(require('chai-as-promised'))
+  .use(require('chai-bignumber')(BigNumber))
+  .should()
+
+const amounts = [1, 5, 10, 15, 20, 50, 100, 150, 200, 500, 1000, 1500, 2000, 5000, 10_000, 15_000, 20_000, 50_000, 100_000, 150_000, 200_000, 500_000, 1_000_000, 1_250_000, 1_500_000, 1_750_000, 2_000_000, 2_250_000, 2_500_000, 2_750_000, 3_000_000, 3_500_000, 4_000_000, 5_000_000, 10_000_000]
+const durations = [1, 2, 3]
+
+const data = {
+  reassuranceAmount: 1_000_000,
+  provision: 0,
+  inVault: 14_000_000,
+  totalCommitment: 0,
+  floor: 0.07,
+  ceiling: 0.45,
+  MULTIPLIER,
+  INCIDENT_SUPPORT_POOL_CAP_RATIO
+}
+
+const payload = {
+  reassuranceAmount: ethers.BigNumber.from(helper.ether(data.reassuranceAmount)),
+  provision: ethers.BigNumber.from(helper.ether(data.provision)),
+  inVault: ethers.BigNumber.from(helper.ether(data.inVault)),
+  totalCommitment: ethers.BigNumber.from(helper.ether(data.totalCommitment)),
+  floor: ethers.BigNumber.from(helper.percentage(7)),
+  ceiling: ethers.BigNumber.from(helper.percentage(45)),
+  MULTIPLIER,
+  INCIDENT_SUPPORT_POOL_CAP_RATIO
+}
+
+const getFee = (amount, duration) => getCoverFee(data, amount, duration, false)
+
+describe('Policy: calculatePolicyFee', () => {
+  let deployed, coverKey
+
+  before(async () => {
+    const [owner] = await ethers.getSigners()
+    deployed = await deployDependencies()
+
+    deployed.policy = await deployer.deployWithLibraries(cache, 'Policy', {
+      AccessControlLibV1: deployed.accessControlLibV1.address,
+      BaseLibV1: deployed.baseLibV1.address,
+      CoverUtilV1: deployed.coverUtilV1.address,
+      PolicyHelperV1: deployed.policyHelperV1.address,
+      StrategyLibV1: deployed.strategyLibV1.address,
+      ValidationLibV1: deployed.validationLibV1.address
+    }, deployed.store.address)
+
+    await deployed.protocol.addContract(key.PROTOCOL.CNS.COVER_POLICY, deployed.policy.address)
+
+    coverKey = key.toBytes32('foo-bar')
+    const stakeWithFee = helper.ether(10_000)
+    const minReportingStake = helper.ether(250)
+    const reportingPeriod = 7 * DAYS
+    const cooldownPeriod = 1 * DAYS
+    const claimPeriod = 7 * DAYS
+
+    const requiresWhitelist = false
+    const values = [stakeWithFee, payload.reassuranceAmount, minReportingStake, reportingPeriod, cooldownPeriod, claimPeriod, payload.floor, payload.ceiling]
+
+    const info = await ipfs.write([coverKey, ...values])
+
+    deployed.cover.updateCoverCreatorWhitelist(owner.address, true)
+
+    await deployed.npm.approve(deployed.stakingContract.address, stakeWithFee)
+    await deployed.dai.approve(deployed.reassuranceContract.address, payload.reassuranceAmount)
+
+    await deployed.cover.addCover(coverKey, info, deployed.dai.address, requiresWhitelist, values)
+    await deployed.cover.deployVault(coverKey)
+
+    deployed.vault = await composer.vault.getVault({
+      store: deployed.store,
+      libs: {
+        accessControlLibV1: deployed.accessControlLibV1,
+        baseLibV1: deployed.baseLibV1,
+        transferLib: deployed.transferLib,
+        protoUtilV1: deployed.protoUtilV1,
+        registryLibV1: deployed.registryLibV1,
+        validationLib: deployed.validationLibV1
+      }
+    }, coverKey)
+
+    await deployed.dai.approve(deployed.vault.address, payload.inVault)
+    await deployed.npm.approve(deployed.vault.address, minReportingStake)
+    await deployed.vault.addLiquidity(coverKey, payload.inVault, minReportingStake)
+  })
+
+  for (const amount of amounts) {
+    for (const duration of durations) {
+      const expected = helper.formatCurrency(getFee(amount, duration), 4).trim()
+
+      it(`must return fee: ${expected} to cover ${helper.formatCurrency(amount, 0)} for ${duration} month(s)`, async () => {
+        const fees = await deployed.policy.calculatePolicyFee(coverKey, duration.toString(), helper.ether(amount))
+
+        expected.should.equal(helper.formatCurrency(helper.weiToEther(fees), 4))
+      })
+    }
+  }
+
+  it('must revert if zero is specified as the amount to cover', async () => {
+    await deployed.policy.calculatePolicyFee(coverKey, '1', helper.ether(0))
+      .should.be.rejectedWith('Please enter an amount')
+  })
+
+  it('must revert if invalid value is specified as the cover duration', async () => {
+    await deployed.policy.calculatePolicyFee(coverKey, '0', helper.ether(10000))
+      .should.be.rejectedWith('Invalid duration')
+  })
+})

--- a/test/specs/policy/get-cxtoken-by-expiry-date.spec.js
+++ b/test/specs/policy/get-cxtoken-by-expiry-date.spec.js
@@ -76,7 +76,9 @@ describe('Policy: getCxTokenByExpiryDate', function () {
     await deployed.dai.approve(deployed.policy.address, ethers.constants.MaxUint256)
     await deployed.policy.purchaseCover(coverKey, '1', helper.ether(500_000))
 
-    const expiryDate = await deployed.policy.getExpiryDate(moment().unix().toString(), '1')
+    const block = await ethers.provider.getBlock(await ethers.provider.getBlockNumber())
+
+    const expiryDate = await deployed.policy.getExpiryDate(block.timestamp, '1')
     const cxToken = await deployed.policy.getCxTokenByExpiryDate(coverKey, expiryDate)
     cxToken.should.not.equal(helper.zerox)
   })

--- a/test/specs/policy/util/calculator.js
+++ b/test/specs/policy/util/calculator.js
@@ -1,0 +1,72 @@
+const { helper } = require('../../../../util')
+
+const getCoverFee = (data, amount, duration, debug = false) => {
+  const truncate = (x, precision) => Math.trunc(x * Math.pow(10, precision)) / Math.pow(10, precision)
+
+  if (!amount) {
+    return
+  }
+
+  data.supportPool = (data.reassuranceAmount + data.provision) * data.INCIDENT_SUPPORT_POOL_CAP_RATIO / data.MULTIPLIER
+  data.totalAvailableLiquidity = data.inVault + data.supportPool
+
+  if (amount > data.totalAvailableLiquidity) {
+    throw new Error('Balance insufficient')
+  }
+
+  // solidity-like truncation
+  data.utilizationRatio = truncate(((data.totalCommitment + amount) / data.totalAvailableLiquidity), 4)
+
+  debug && console.debug('s: %s. p: %s. u: %s', data.inVault, data.supportPool, data.utilizationRatio)
+  debug && console.debug('c: %s, a: %s. t: %s', data.totalCommitment, amount, data.totalAvailableLiquidity)
+
+  let rate = data.utilizationRatio > data.floor ? data.utilizationRatio : data.floor
+
+  debug && console.debug('rs1 -->', helper.formatPercent(rate))
+
+  rate = rate + (duration * 100 / data.MULTIPLIER)
+
+  debug && console.debug('rs2 -->', helper.formatPercent(rate))
+
+  if (rate > data.ceiling) {
+    rate = data.ceiling
+  }
+
+  debug && console.debug('rs3 -->', helper.formatPercent(rate))
+
+  data.rate = rate
+  data.projectedFee = (data.rate * amount * duration) / 12
+
+  return data.projectedFee
+}
+
+const getCoverFeeBn = (payload, amount, duration, debug = false) => {
+  const supportPool = payload.reassuranceAmount.add(payload.provision).mul(payload.INCIDENT_SUPPORT_POOL_CAP_RATIO.toString()).div(payload.MULTIPLIER.toString())
+  const totalAvailableLiquidity = payload.inVault.add(supportPool)
+
+  if (amount.gt(totalAvailableLiquidity)) {
+    throw new Error('Balance insufficient')
+  }
+
+  const utilizationRatio = payload.totalCommitment.add(amount).mul(payload.MULTIPLIER).div(totalAvailableLiquidity)
+  debug && console.debug('s: %s. p: %s. u: %s', payload.inVault, supportPool, utilizationRatio)
+  debug && console.debug('c: %s, a: %s. t: %s', payload.totalCommitment, amount, totalAvailableLiquidity)
+
+  let rate = utilizationRatio.gt(payload.floor) ? utilizationRatio : payload.floor
+
+  debug && console.debug('rs1 -->', helper.formatPercentBn(rate))
+
+  rate = rate.add(duration.mul(100))
+
+  debug && console.debug('rs2 -->', helper.formatPercentBn(rate))
+
+  if (rate.gt(payload.ceiling)) {
+    rate = payload.ceiling
+  }
+
+  debug && console.debug('rs3 -->', helper.formatPercentBn(rate))
+
+  return rate.mul(amount).mul(duration).div(12 * payload.MULTIPLIER)
+}
+
+module.exports = { getCoverFee, getCoverFeeBn }

--- a/test/specs/policy/util/calculator.spec.js
+++ b/test/specs/policy/util/calculator.spec.js
@@ -35,12 +35,8 @@ const payload = {
 const getFee = (amount, duration) => getCoverFee(data, amount, duration, false)
 const getFeeBn = (amount, duration) => getCoverFeeBn(payload, amount, duration, false)
 
-const check = (cases) => {
-
-}
-
-describe('Calculator test', () => {
-  const amounts = [1, 5, 10, 15, 20, 50, 100, 150, 200, 500, 1000, 1500, 2000, 5000, 10_000, 15_000, 20_000, 50_000, 100_000, 150_000, 200_000, 500_000, 1_000_000, 1_250_000, 1_500_000, 1_750_000, 2_000_000, 2_250_000, 2_500_000, 2_750_000, 3_000_000, 3_500_000, 4_000_000, 5_000_000, 10_000_000]
+describe('Policy Fee Calculation tests', () => {
+  const amounts = [1, 5, 10, 15, 20, 50, 100, 150, 200, 500, 1000, 1500, 2000, 5000, 10_000, 15_000, 20_000, 50_000, 100_000, 150_000, 200_000, 250_000, 500_000, 1_000_000, 1_250_000, 1_500_000, 1_750_000, 2_000_000, 2_250_000, 2_500_000, 2_750_000, 3_000_000, 3_500_000, 4_000_000, 5_000_000, 10_000_000]
   const durations = [1, 2, 3]
   const cases = []
 
@@ -59,6 +55,10 @@ describe('Calculator test', () => {
       const ab = ethers.BigNumber.from(helper.ether(amount))
       const db = ethers.BigNumber.from(duration)
       const fb = helper.weiToEther(getFeeBn(ab, db))
+
+      if (duration === 2 && amount === 500_000) {
+        console.info('Duration %s. Amount: %s. Fee: %s', duration, amount, fee)
+      }
 
       helper.formatCurrency(fee).should.eq(helper.formatCurrency(fb))
     })

--- a/test/specs/policy/util/calculator.spec.js
+++ b/test/specs/policy/util/calculator.spec.js
@@ -1,0 +1,66 @@
+const { ethers } = require('ethers')
+const BigNumber = require('bignumber.js')
+const { helper } = require('../../../../util')
+const { getCoverFee, getCoverFeeBn } = require('./calculator')
+const MULTIPLIER = 10_000
+const INCIDENT_SUPPORT_POOL_CAP_RATIO = 2500
+
+require('chai')
+  .use(require('chai-as-promised'))
+  .use(require('chai-bignumber')(BigNumber))
+  .should()
+
+const data = {
+  reassuranceAmount: 1_000_000,
+  provision: 0,
+  inVault: 24_000_000,
+  totalCommitment: 0,
+  floor: 0.07,
+  ceiling: 0.45,
+  MULTIPLIER,
+  INCIDENT_SUPPORT_POOL_CAP_RATIO
+}
+
+const payload = {
+  reassuranceAmount: ethers.BigNumber.from(helper.ether(data.reassuranceAmount)),
+  provision: ethers.BigNumber.from(helper.ether(data.provision)),
+  inVault: ethers.BigNumber.from(helper.ether(data.inVault)),
+  totalCommitment: ethers.BigNumber.from(helper.ether(data.totalCommitment)),
+  floor: ethers.BigNumber.from(helper.percentage(7)),
+  ceiling: ethers.BigNumber.from(helper.percentage(45)),
+  MULTIPLIER,
+  INCIDENT_SUPPORT_POOL_CAP_RATIO
+}
+
+const getFee = (amount, duration) => getCoverFee(data, amount, duration, false)
+const getFeeBn = (amount, duration) => getCoverFeeBn(payload, amount, duration, false)
+
+const check = (cases) => {
+
+}
+
+describe('Calculator test', () => {
+  const amounts = [1, 5, 10, 15, 20, 50, 100, 150, 200, 500, 1000, 1500, 2000, 5000, 10_000, 15_000, 20_000, 50_000, 100_000, 150_000, 200_000, 500_000, 1_000_000, 1_250_000, 1_500_000, 1_750_000, 2_000_000, 2_250_000, 2_500_000, 2_750_000, 3_000_000, 3_500_000, 4_000_000, 5_000_000, 10_000_000]
+  const durations = [1, 2, 3]
+  const cases = []
+
+  for (const amount of amounts) {
+    for (const duration of durations) {
+      cases.push([amount, duration])
+    }
+  }
+
+  for (const candidate of cases) {
+    const [amount, duration] = candidate
+
+    it(`compares policy fee of ${helper.formatCurrency(amount, 0)} for ${duration} month(s)`, async () => {
+      const fee = getFee(amount, duration)
+
+      const ab = ethers.BigNumber.from(helper.ether(amount))
+      const db = ethers.BigNumber.from(duration)
+      const fb = helper.weiToEther(getFeeBn(ab, db))
+
+      helper.formatCurrency(fee).should.eq(helper.formatCurrency(fb))
+    })
+  }
+})

--- a/test/stories/1. policy.spec.js
+++ b/test/stories/1. policy.spec.js
@@ -29,7 +29,7 @@ describe('Policy Purchase Stories', () => {
 
     const stakeWithFee = helper.ether(10_000)
     const initialReassuranceAmount = helper.ether(1_000_000)
-    const initialLiquidity = helper.ether(4_000_000)
+    const initialLiquidity = helper.ether(24_000_000)
     const minReportingStake = helper.ether(250)
     const reportingPeriod = 7 * DAYS
     const cooldownPeriod = 1 * DAYS
@@ -71,7 +71,7 @@ describe('Policy Purchase Stories', () => {
     const result = await contracts.policy.getCoverPoolSummary(coverKey)
     const [totalAmountInPool, totalCommitment, provision, npmPrice, reassurance, reassurancePrice, reassuranceWeight] = result
 
-    totalAmountInPool.toString().should.equal(helper.ether(4_000_000))
+    totalAmountInPool.toString().should.equal(helper.ether(24_000_000))
     totalCommitment.toString().should.equal(helper.ether(0))
     provision.toString().should.equal(helper.ether(1_000_000))
     npmPrice.toString().should.equal(helper.ether(2))
@@ -80,64 +80,8 @@ describe('Policy Purchase Stories', () => {
     reassuranceWeight.toString().should.equal(helper.percentage(100))
   })
 
-  it('fee should be ~$58.33 DAI when purchasing 10K DAI cover for 1 month', async () => {
-    const result = await contracts.policy.getCoverFeeInfo(coverKey, 1, helper.ether(10_000))
-    const { utilizationRatio, totalAvailableLiquidity, coverRatio, floor, ceiling, rate, fee } = result
-
-    utilizationRatio.toString().should.equal(helper.ether(0))
-    totalAvailableLiquidity.toString().should.equal(helper.ether(7_000_000))
-
-    helper.toPercentageString(coverRatio).should.equal('0.14')
-    helper.toPercentageString(floor).should.equal('7.00')
-    helper.toPercentageString(ceiling).should.equal('45.00')
-    helper.toPercentageString(rate).should.equal('7.00')
-
-    helper.weiToEther(fee).toFixed(2).should.equal('58.33')
-  })
-
-  it('fee should be ~$7,255.84 when purchasing 250K DAI cover for 3 months', async () => {
-    const result = await contracts.policy.getCoverFeeInfo(coverKey, 3, helper.ether(250_000))
-    const { utilizationRatio, totalAvailableLiquidity, coverRatio, floor, ceiling, rate, fee } = result
-
-    utilizationRatio.toString().should.equal(helper.ether(0))
-    totalAvailableLiquidity.toString().should.equal(helper.ether(7_000_000))
-
-    helper.toPercentageString(coverRatio).should.equal('10.71')
-    helper.toPercentageString(floor).should.equal('7.00')
-    helper.toPercentageString(ceiling).should.equal('45.00')
-    helper.toPercentageString(rate).should.equal('11.60')
-
-    helper.weiToEther(fee).toFixed(2).should.equal('7250.00')
-  })
-
-  it('fee should be ~4095.83 when purchasing 500K DAI cover for 1 month', async () => {
-    const result = await contracts.policy.getCoverFeeInfo(coverKey, 1, helper.ether(500_000))
-    const { utilizationRatio, totalAvailableLiquidity, coverRatio, rate, fee } = result
-
-    utilizationRatio.toString().should.equal(helper.ether(0))
-    totalAvailableLiquidity.toString().should.equal(helper.ether(7_000_000))
-
-    helper.toPercentageString(coverRatio).should.equal('7.14')
-    helper.toPercentageString(rate).should.equal('9.83')
-
-    helper.weiToEther(fee).toFixed(2).should.equal('4095.83')
-  })
-
-  it('fee should be ~$10633.33 when purchasing 500K DAI cover for 2 months', async () => {
-    const result = await contracts.policy.getCoverFeeInfo(coverKey, 2, helper.ether(500_000))
-    const { utilizationRatio, totalAvailableLiquidity, coverRatio, rate, fee } = result
-
-    utilizationRatio.toString().should.equal(helper.ether(0))
-    totalAvailableLiquidity.toString().should.equal(helper.ether(7_000_000))
-
-    helper.toPercentageString(coverRatio).should.equal('14.28')
-    helper.toPercentageString(rate).should.equal('12.76')
-
-    helper.weiToEther(fee).toFixed(2).should.equal('10633.33')
-  })
-
   it('let\'s purchase a policy for `Compound Finance Cover`', async () => {
-    const args = [coverKey, 2, helper.ether(500_000)]
+    const args = [coverKey, 2, helper.ether(2_500_000)]
     const { fee } = await contracts.policy.getCoverFeeInfo(...args)
 
    ;(await contracts.policy.getCxToken(args[0], args[1]))[0].should.equal(helper.zerox)
@@ -149,8 +93,54 @@ describe('Policy Purchase Stories', () => {
     const cxToken = await composer.token.at(cxTokenAddress)
 
     const [owner] = await ethers.getSigners()
-    const cBal = await cxToken.balanceOf(owner.address)
+    const cxDaiBalance = await cxToken.balanceOf(owner.address)
 
-    cBal.toString().should.equal(args[2].toString())
+    cxDaiBalance.toString().should.equal(args[2].toString())
+  })
+
+  it('fee should be ~85.67 DAI when purchasing 10K DAI cover for 1 month', async () => {
+    const result = await contracts.policy.getCoverFeeInfo(coverKey, 1, helper.ether(10_000))
+    const { fee } = result
+
+    helper.weiToEther(fee).toFixed(2).should.equal('85.67')
+  })
+
+  it('fee should be ~$8225 when purchasing 250K DAI cover for 3 months', async () => {
+    const result = await contracts.policy.getCoverFeeInfo(coverKey, 3, helper.ether(250_000))
+    const { fee } = result
+
+    helper.weiToEther(fee).toFixed(2).should.equal('8225.00')
+  })
+
+  it('fee should be ~5037.50 when purchasing 500K DAI cover for 1 month', async () => {
+    const result = await contracts.policy.getCoverFeeInfo(coverKey, 1, helper.ether(500_000))
+    const { fee } = result
+
+    helper.weiToEther(fee).toFixed(2).should.equal('5037.50')
+  })
+
+  it('fee should be ~$10908.33 when purchasing 500K DAI cover for 2 months', async () => {
+    const result = await contracts.policy.getCoverFeeInfo(coverKey, 2, helper.ether(500_000))
+    const { fee } = result
+
+    helper.weiToEther(fee).toFixed(2).should.equal('10908.33')
+  })
+
+  it('let\'s purchase a policy for `Compound Finance Cover` again', async () => {
+    const args = [coverKey, 2, helper.ether(500_000)]
+    const { fee } = await contracts.policy.getCoverFeeInfo(...args)
+
+   ;(await contracts.policy.getCxToken(args[0], args[1]))[0].should.not.equal(helper.zerox)
+
+    await contracts.dai.approve(contracts.policy.address, fee)
+    await contracts.policy.purchaseCover(...args)
+
+    const { cxToken: cxTokenAddress } = await contracts.policy.getCxToken(args[0], args[1])
+    const cxToken = await composer.token.at(cxTokenAddress)
+
+    const [owner] = await ethers.getSigners()
+    const cxDaiBalance = await cxToken.balanceOf(owner.address)
+
+    cxDaiBalance.toString().should.equal(helper.ether(3_000_000))
   })
 })

--- a/util/helper.js
+++ b/util/helper.js
@@ -18,8 +18,26 @@ const zerox = '0x0000000000000000000000000000000000000000'
 const zero1 = '0x0000000000000000000000000000000000000001'
 const sum = (x) => x.reduce((y, z) => y + z)
 const getRandomNumber = (min, max) => Math.ceil(Math.floor(Math.random() * (max - min + 1)) + min)
-const formatToken = (x, symbol) => Number(x).toLocaleString(undefined, { minimumFractionDigits: 2 }) + (` ${symbol}` || '')
+const formatToken = (x, symbol) => Number(x).toLocaleString('en-US', { minimumFractionDigits: 4 }) + (` ${symbol}` || '')
 const weiAsToken = (x, symbol) => formatToken(weiToEther(x), symbol)
+const formatCurrency = (x, precision = 4) => Number(x).toLocaleString(undefined, { currency: 'USD', style: 'currency', minimumFractionDigits: precision })
+
+const formatPercent = (x) => {
+  if (!x || isNaN(x)) {
+    return ''
+  }
+
+  const percent = parseFloat(x) * 100
+
+  return new Intl.NumberFormat('en-US', {
+    style: 'percent',
+    maximumFractionDigits: percent < 1 ? 6 : 2
+  }).format(x)
+}
+
+const formatPercentBn = (x) => {
+  return formatPercent(x.toNumber() / MULTIPLIER) + ' (BN)'
+}
 
 const coverStatus = {
   normal: 0,
@@ -43,5 +61,8 @@ module.exports = {
   coverStatus,
   sum,
   getRandomNumber,
-  weiAsToken
+  weiAsToken,
+  formatCurrency,
+  formatPercent,
+  formatPercentBn
 }


### PR DESCRIPTION
- Added a new function `calculatePolicyFee` to replace `getCoverFee`
- Refactored helper util
- Replaced `getCoverFeeInfo` logic with `calculatePolicyFee` and dropped the latter
- Dropped obsolete arg `coverRatio` from `getCoverFeeInfo`
- Renamed `getCoverFee` to `getCoverCreationFeeInfo` for added clarity
- Dropped unused function `getCoverFeeInfoInternal`
- Renamed `getCoverFeeInternal` to `getPolicyFeeInternal`
- Refactored and added tests