### PR TITLE
Fixed reporting `unstake` and added tests

### DIFF
--- a/contracts/core/governance/Reporter.sol
+++ b/contracts/core/governance/Reporter.sol
@@ -37,7 +37,7 @@ abstract contract Reporter is IReporter, Witness {
     s.mustHaveNormalCoverStatus(key);
 
     uint256 incidentDate = block.timestamp; // solhint-disable-line
-    require(stake >= 0, "Stake insufficient");
+    require(stake > 0, "Stake insufficient");
     require(stake >= s.getMinReportingStake(key), "Stake insufficient");
 
     s.setUintByKeys(ProtoUtilV1.NS_GOVERNANCE_REPORTING_INCIDENT_DATE, key, incidentDate);
@@ -70,7 +70,7 @@ abstract contract Reporter is IReporter, Witness {
     s.mustBeValidIncidentDate(key, incidentDate);
     s.mustBeDuringReportingPeriod(key);
 
-    require(stake >= 0, "Stake insufficient");
+    require(stake > 0, "Stake insufficient");
     require(stake >= s.getMinReportingStake(key), "Stake insufficient");
 
     s.addDispute(key, msg.sender, incidentDate, stake);

--- a/contracts/core/governance/resolution/Resolvable.sol
+++ b/contracts/core/governance/resolution/Resolvable.sol
@@ -117,7 +117,6 @@ abstract contract Resolvable is Finalization, IResolvable {
   function configureCoolDownPeriod(bytes32 key, uint256 period) external override nonReentrant {
     s.mustNotBePaused();
     AccessControlLibV1.mustBeGovernanceAdmin(s);
-    s.mustHaveNormalCoverStatus(key);
 
     require(period > 0, "Please specify period");
 

--- a/contracts/core/governance/resolution/Unstakable.sol
+++ b/contracts/core/governance/resolution/Unstakable.sol
@@ -58,6 +58,8 @@ abstract contract Unstakable is Resolvable, IUnstakable {
    * @param incidentDate Enter the incident date
    */
   function unstakeWithClaim(bytes32 key, uint256 incidentDate) external override nonReentrant {
+    require(incidentDate > 0, "Please specify incident date");
+
     // @suppress-acl Marking this as publicly accessible
     // @suppress-pausable Already checked inside `validateUnstakeWithClaim`
     s.validateUnstakeWithClaim(key, incidentDate);

--- a/contracts/libraries/ValidationLibV1.sol
+++ b/contracts/libraries/ValidationLibV1.sol
@@ -314,7 +314,7 @@ library ValidationLibV1 {
     // that may have an impact on the final decision. We, therefore, have to wait.
     mustBeAfterResolutionDeadline(s, key);
 
-    bool incidentHappened = s.getCoverStatus(key) == CoverUtilV1.CoverStatus.IncidentHappened;
+    bool incidentHappened = s.getCoverStatus(key) == CoverUtilV1.CoverStatus.Claimable;
 
     if (incidentHappened) {
       // Incident occurred. Must unstake with claim during the claim period.

--- a/test/specs/governance/attest.spec.js
+++ b/test/specs/governance/attest.spec.js
@@ -1,0 +1,197 @@
+/* eslint-disable no-unused-expressions */
+const { ethers, network } = require('hardhat')
+const BigNumber = require('bignumber.js')
+const { helper, deployer, key } = require('../../../util')
+const composer = require('../../../util/composer')
+const { deployDependencies } = require('./deps')
+const cache = null
+const DAYS = 86400
+
+require('chai')
+  .use(require('chai-as-promised'))
+  .use(require('chai-bignumber')(BigNumber))
+  .should()
+
+describe('Governance: attest', () => {
+  let deployed, coverKey
+
+  before(async () => {
+    const [owner] = await ethers.getSigners()
+    deployed = await deployDependencies()
+
+    deployed.policy = await deployer.deployWithLibraries(cache, 'Policy', {
+      AccessControlLibV1: deployed.accessControlLibV1.address,
+      BaseLibV1: deployed.baseLibV1.address,
+      CoverUtilV1: deployed.coverUtilV1.address,
+      PolicyHelperV1: deployed.policyHelperV1.address,
+      StrategyLibV1: deployed.strategyLibV1.address,
+      ValidationLibV1: deployed.validationLibV1.address
+    }, deployed.store.address)
+
+    await deployed.protocol.addContract(key.PROTOCOL.CNS.COVER_POLICY, deployed.policy.address)
+
+    coverKey = key.toBytes32('foo-bar')
+    const stakeWithFee = helper.ether(10_000)
+    const initialReassuranceAmount = helper.ether(1_000_000)
+    const initialLiquidity = helper.ether(4_000_000)
+    const minReportingStake = helper.ether(250)
+    const reportingPeriod = 7 * DAYS
+    const cooldownPeriod = 1 * DAYS
+    const claimPeriod = 7 * DAYS
+    const floor = helper.percentage(7)
+    const ceiling = helper.percentage(45)
+
+    const requiresWhitelist = false
+    const values = [stakeWithFee, initialReassuranceAmount, minReportingStake, reportingPeriod, cooldownPeriod, claimPeriod, floor, ceiling]
+
+    const info = key.toBytes32('info')
+
+    deployed.cover.updateCoverCreatorWhitelist(owner.address, true)
+
+    await deployed.npm.approve(deployed.stakingContract.address, stakeWithFee)
+    await deployed.dai.approve(deployed.reassuranceContract.address, initialReassuranceAmount)
+
+    await deployed.cover.addCover(coverKey, info, deployed.dai.address, requiresWhitelist, values)
+    await deployed.cover.deployVault(coverKey)
+
+    deployed.vault = await composer.vault.getVault({
+      store: deployed.store,
+      libs: {
+        accessControlLibV1: deployed.accessControlLibV1,
+        baseLibV1: deployed.baseLibV1,
+        transferLib: deployed.transferLib,
+        protoUtilV1: deployed.protoUtilV1,
+        registryLibV1: deployed.registryLibV1,
+        validationLib: deployed.validationLibV1
+      }
+    }, coverKey)
+
+    await deployed.dai.approve(deployed.vault.address, initialLiquidity)
+    await deployed.npm.approve(deployed.vault.address, minReportingStake)
+    await deployed.vault.addLiquidity(coverKey, initialLiquidity, minReportingStake)
+  })
+
+  it('must attest correctly', async () => {
+    const [bob] = await ethers.getSigners()
+
+    await deployed.npm.transfer(bob.address, helper.ether(1000))
+
+    const reportingInfo = key.toBytes32('reporting-info')
+    await deployed.npm.approve(deployed.governance.address, helper.ether(1000))
+    await deployed.governance.report(coverKey, reportingInfo, helper.ether(1000))
+
+    const incidentDate = await deployed.governance.getActiveIncidentDate(coverKey)
+
+    await deployed.npm.connect(bob).approve(deployed.governance.address, helper.ether(1000))
+    const tx = await deployed.governance.connect(bob).attest(coverKey, incidentDate, helper.ether(1000))
+    const { events } = await tx.wait()
+    const event = events.find(x => x.event === 'Attested')
+
+    event.args.key.should.equal(coverKey)
+    event.args.incidentDate.should.equal(incidentDate)
+    event.args.witness.should.equal(bob.address)
+    event.args.stake.should.equal(helper.ether(1000))
+
+    // Cleanup - resolve, finalize
+    // Reporting period + 1 second
+    await network.provider.send('evm_increaseTime', [7 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    await deployed.resolution.resolve(coverKey, incidentDate)
+    // Cooldown period + 1 second
+    await network.provider.send('evm_increaseTime', [1 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    // Claim period + 1 second
+    await network.provider.send('evm_increaseTime', [7 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    await deployed.resolution.finalize(coverKey, incidentDate)
+  })
+
+  it('reverts when tried to attest after reporting period', async () => {
+    const [bob] = await ethers.getSigners()
+
+    await deployed.npm.transfer(bob.address, helper.ether(1000))
+
+    const reportingInfo = key.toBytes32('reporting-info')
+    await deployed.npm.approve(deployed.governance.address, helper.ether(1000))
+    await deployed.governance.report(coverKey, reportingInfo, helper.ether(1000))
+
+    const incidentDate = await deployed.governance.getActiveIncidentDate(coverKey)
+
+    // Reporting period + 1 second
+    await network.provider.send('evm_increaseTime', [7 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+
+    await deployed.npm.connect(bob).approve(deployed.governance.address, helper.ether(1000))
+    await deployed.governance.connect(bob).attest(coverKey, incidentDate, helper.ether(1000))
+      .should.be.rejectedWith('Reporting window closed')
+
+    // Cleanup - resolve, finalize
+    await deployed.resolution.resolve(coverKey, incidentDate)
+    // Cooldown period + 1 second
+    await network.provider.send('evm_increaseTime', [1 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    // Claim period + 1 second
+    await network.provider.send('evm_increaseTime', [7 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    await deployed.resolution.finalize(coverKey, incidentDate)
+  })
+
+  it('reverts when tried to attest after resolved', async () => {
+    const [bob] = await ethers.getSigners()
+
+    await deployed.npm.transfer(bob.address, helper.ether(1000))
+
+    const reportingInfo = key.toBytes32('reporting-info')
+    await deployed.npm.approve(deployed.governance.address, helper.ether(1000))
+    await deployed.governance.report(coverKey, reportingInfo, helper.ether(1000))
+
+    const incidentDate = await deployed.governance.getActiveIncidentDate(coverKey)
+
+    // Reporting period + 1 second
+    await network.provider.send('evm_increaseTime', [7 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    await deployed.resolution.resolve(coverKey, incidentDate)
+
+    await deployed.npm.connect(bob).approve(deployed.governance.address, helper.ether(1000))
+    await deployed.governance.connect(bob).attest(coverKey, incidentDate, helper.ether(1000))
+      .should.be.rejectedWith('Not reported nor disputed')
+
+    // Cleanup - finalize
+    // Cooldown period + 1 second
+    await network.provider.send('evm_increaseTime', [1 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    // Claim period + 1 second
+    await network.provider.send('evm_increaseTime', [7 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    await deployed.resolution.finalize(coverKey, incidentDate)
+  })
+
+  it('reverts when invalid value is passed as stake', async () => {
+    const [bob] = await ethers.getSigners()
+
+    await deployed.npm.transfer(bob.address, helper.ether(1000))
+
+    const reportingInfo = key.toBytes32('reporting-info')
+    await deployed.npm.approve(deployed.governance.address, helper.ether(1000))
+    await deployed.governance.report(coverKey, reportingInfo, helper.ether(1000))
+
+    const incidentDate = await deployed.governance.getActiveIncidentDate(coverKey)
+
+    await deployed.npm.connect(bob).approve(deployed.governance.address, helper.ether(0))
+    await deployed.governance.connect(bob).attest(coverKey, incidentDate, helper.ether(0))
+      .should.be.rejectedWith('Enter a stake')
+
+    // Cleanup - resolve, finalize
+    // Reporting period + 1 second
+    await network.provider.send('evm_increaseTime', [7 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    await deployed.resolution.resolve(coverKey, incidentDate)
+    // Cooldown period + 1 second
+    await network.provider.send('evm_increaseTime', [1 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    // Claim period + 1 second
+    await network.provider.send('evm_increaseTime', [7 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    await deployed.resolution.finalize(coverKey, incidentDate)
+  })
+})

--- a/test/specs/governance/deps.js
+++ b/test/specs/governance/deps.js
@@ -106,6 +106,15 @@ const deployDependencies = async () => {
     ValidationLibV1: validationLibV1.address
   })
 
+  const policyHelperV1 = await deployer.deployWithLibraries(cache, 'PolicyHelperV1', {
+    CoverUtilV1: coverUtilV1.address,
+    NTransferUtilV2: transferLib.address,
+    ProtoUtilV1: protoUtilV1.address,
+    RegistryLibV1: registryLibV1.address,
+    RoutineInvokerLibV1: routineInvokerLibV1.address,
+    StoreKeyUtil: storeKeyUtil.address
+  })
+
   const protocol = await deployer.deployWithLibraries(cache, 'Protocol',
     {
       AccessControlLibV1: accessControlLibV1.address,
@@ -143,7 +152,16 @@ const deployDependencies = async () => {
     ]
   )
 
-  await protocol.grantRoles([{ account: owner.address, roles: [key.ACCESS_CONTROL.UPGRADE_AGENT, key.ACCESS_CONTROL.COVER_MANAGER, key.ACCESS_CONTROL.LIQUIDITY_MANAGER, key.ACCESS_CONTROL.PAUSE_AGENT, key.ACCESS_CONTROL.UNPAUSE_AGENT] }])
+  await protocol.grantRoles([{
+    account: owner.address,
+    roles: [key.ACCESS_CONTROL.UPGRADE_AGENT,
+      key.ACCESS_CONTROL.COVER_MANAGER,
+      key.ACCESS_CONTROL.LIQUIDITY_MANAGER,
+      key.ACCESS_CONTROL.GOVERNANCE_AGENT,
+      key.ACCESS_CONTROL.GOVERNANCE_ADMIN,
+      key.ACCESS_CONTROL.PAUSE_AGENT,
+      key.ACCESS_CONTROL.UNPAUSE_AGENT]
+  }])
   await protocol.grantRole(key.ACCESS_CONTROL.UPGRADE_AGENT, protocol.address)
 
   const cover = await deployer.deployWithLibraries(cache, 'Cover',
@@ -318,7 +336,7 @@ const deployDependencies = async () => {
     routineInvokerLibV1,
     cover,
     coverLibV1,
-    // policyHelperV1,
+    policyHelperV1,
     stakingPoolLibV1,
     strategyLibV1,
     stakingContract,

--- a/test/specs/governance/dispute.spec.js
+++ b/test/specs/governance/dispute.spec.js
@@ -1,0 +1,238 @@
+/* eslint-disable no-unused-expressions */
+const { ethers, network } = require('hardhat')
+const BigNumber = require('bignumber.js')
+const { helper, deployer, key } = require('../../../util')
+const composer = require('../../../util/composer')
+const { deployDependencies } = require('./deps')
+const cache = null
+const DAYS = 86400
+
+require('chai')
+  .use(require('chai-as-promised'))
+  .use(require('chai-bignumber')(BigNumber))
+  .should()
+
+describe('Governance: dispute', () => {
+  let deployed, coverKey
+
+  before(async () => {
+    const [owner] = await ethers.getSigners()
+    deployed = await deployDependencies()
+
+    deployed.policy = await deployer.deployWithLibraries(cache, 'Policy', {
+      AccessControlLibV1: deployed.accessControlLibV1.address,
+      BaseLibV1: deployed.baseLibV1.address,
+      CoverUtilV1: deployed.coverUtilV1.address,
+      PolicyHelperV1: deployed.policyHelperV1.address,
+      StrategyLibV1: deployed.strategyLibV1.address,
+      ValidationLibV1: deployed.validationLibV1.address
+    }, deployed.store.address)
+
+    await deployed.protocol.addContract(key.PROTOCOL.CNS.COVER_POLICY, deployed.policy.address)
+
+    coverKey = key.toBytes32('foo-bar')
+    const stakeWithFee = helper.ether(10_000)
+    const initialReassuranceAmount = helper.ether(1_000_000)
+    const initialLiquidity = helper.ether(4_000_000)
+    const minReportingStake = helper.ether(250)
+    const reportingPeriod = 7 * DAYS
+    const cooldownPeriod = 1 * DAYS
+    const claimPeriod = 7 * DAYS
+    const floor = helper.percentage(7)
+    const ceiling = helper.percentage(45)
+
+    const requiresWhitelist = false
+    const values = [stakeWithFee, initialReassuranceAmount, minReportingStake, reportingPeriod, cooldownPeriod, claimPeriod, floor, ceiling]
+
+    const info = key.toBytes32('info')
+
+    deployed.cover.updateCoverCreatorWhitelist(owner.address, true)
+
+    await deployed.npm.approve(deployed.stakingContract.address, stakeWithFee)
+    await deployed.dai.approve(deployed.reassuranceContract.address, initialReassuranceAmount)
+
+    await deployed.cover.addCover(coverKey, info, deployed.dai.address, requiresWhitelist, values)
+    await deployed.cover.deployVault(coverKey)
+
+    deployed.vault = await composer.vault.getVault({
+      store: deployed.store,
+      libs: {
+        accessControlLibV1: deployed.accessControlLibV1,
+        baseLibV1: deployed.baseLibV1,
+        transferLib: deployed.transferLib,
+        protoUtilV1: deployed.protoUtilV1,
+        registryLibV1: deployed.registryLibV1,
+        validationLib: deployed.validationLibV1
+      }
+    }, coverKey)
+
+    await deployed.dai.approve(deployed.vault.address, initialLiquidity)
+    await deployed.npm.approve(deployed.vault.address, minReportingStake)
+    await deployed.vault.addLiquidity(coverKey, initialLiquidity, minReportingStake)
+  })
+
+  it('must dispute correctly', async () => {
+    const [bob] = await ethers.getSigners()
+
+    await deployed.npm.transfer(bob.address, helper.ether(2000))
+
+    const reportingInfo = key.toBytes32('reporting-info')
+    await deployed.npm.approve(deployed.governance.address, helper.ether(1000))
+    await deployed.governance.report(coverKey, reportingInfo, helper.ether(1000))
+
+    const incidentDate = await deployed.governance.getActiveIncidentDate(coverKey)
+
+    const disputeInfo = key.toBytes32('dispute-info')
+    await deployed.npm.connect(bob).approve(deployed.governance.address, helper.ether(1000))
+    const tx = await deployed.governance.connect(bob).dispute(coverKey, incidentDate, disputeInfo, helper.ether(1000))
+    const { events } = await tx.wait()
+
+    const refutedEvent = events.find(x => x.event === 'Refuted')
+    refutedEvent.args.key.should.equal(coverKey)
+    refutedEvent.args.incidentDate.should.equal(incidentDate)
+    refutedEvent.args.witness.should.equal(bob.address)
+    refutedEvent.args.stake.should.equal(helper.ether(1000))
+
+    const disputedEvent = events.find(x => x.event === 'Disputed')
+    disputedEvent.args.key.should.equal(coverKey)
+    disputedEvent.args.reporter.should.equal(bob.address)
+    disputedEvent.args.incidentDate.should.equal(incidentDate)
+    disputedEvent.args.info.should.equal(disputeInfo)
+    disputedEvent.args.initialStake.should.equal(helper.ether(1000))
+
+    // Cleanup - resolve, finalize
+    // Reporting period + 1 second
+    await network.provider.send('evm_increaseTime', [7 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    await deployed.resolution.resolve(coverKey, incidentDate)
+    // Cooldown period + 1 second
+    await network.provider.send('evm_increaseTime', [1 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    // Claim period + 1 second
+    await network.provider.send('evm_increaseTime', [7 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    await deployed.resolution.finalize(coverKey, incidentDate)
+  })
+
+  it('reverts when tried to dispute after reporting period', async () => {
+    const [bob] = await ethers.getSigners()
+
+    await deployed.npm.transfer(bob.address, helper.ether(2000))
+
+    const reportingInfo = key.toBytes32('reporting-info')
+    await deployed.npm.approve(deployed.governance.address, helper.ether(1000))
+    await deployed.governance.report(coverKey, reportingInfo, helper.ether(1000))
+
+    const incidentDate = await deployed.governance.getActiveIncidentDate(coverKey)
+
+    // Reporting period + 1 second
+    await network.provider.send('evm_increaseTime', [7 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+
+    const disputeInfo = key.toBytes32('dispute-info')
+    await deployed.npm.connect(bob).approve(deployed.governance.address, helper.ether(1000))
+    await deployed.governance.connect(bob).dispute(coverKey, incidentDate, disputeInfo, helper.ether(1000))
+      .should.be.rejectedWith('Reporting window closed')
+
+    // Cleanup - resolve, finalize
+    await deployed.resolution.resolve(coverKey, incidentDate)
+    // Cooldown period + 1 second
+    await network.provider.send('evm_increaseTime', [1 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    // Claim period + 1 second
+    await network.provider.send('evm_increaseTime', [7 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    await deployed.resolution.finalize(coverKey, incidentDate)
+  })
+
+  it('reverts when tried to dispute after resolved', async () => {
+    const [bob] = await ethers.getSigners()
+
+    await deployed.npm.transfer(bob.address, helper.ether(2000))
+
+    const reportingInfo = key.toBytes32('reporting-info')
+    await deployed.npm.approve(deployed.governance.address, helper.ether(1000))
+    await deployed.governance.report(coverKey, reportingInfo, helper.ether(1000))
+
+    const incidentDate = await deployed.governance.getActiveIncidentDate(coverKey)
+
+    // Reporting period + 1 second
+    await network.provider.send('evm_increaseTime', [7 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    await deployed.resolution.resolve(coverKey, incidentDate)
+
+    const disputeInfo = key.toBytes32('dispute-info')
+    await deployed.npm.connect(bob).approve(deployed.governance.address, helper.ether(1000))
+    await deployed.governance.connect(bob).dispute(coverKey, incidentDate, disputeInfo, helper.ether(1000))
+      .should.be.rejectedWith('Not reporting')
+
+    // Cleanup - finalize
+    // Cooldown period + 1 second
+    await network.provider.send('evm_increaseTime', [1 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    // Claim period + 1 second
+    await network.provider.send('evm_increaseTime', [7 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    await deployed.resolution.finalize(coverKey, incidentDate)
+  })
+
+  it('reverts when invalid value is passed as stake', async () => {
+    const [bob] = await ethers.getSigners()
+
+    await deployed.npm.transfer(bob.address, helper.ether(2000))
+
+    const reportingInfo = key.toBytes32('reporting-info')
+    await deployed.npm.approve(deployed.governance.address, helper.ether(1000))
+    await deployed.governance.report(coverKey, reportingInfo, helper.ether(1000))
+
+    const incidentDate = await deployed.governance.getActiveIncidentDate(coverKey)
+
+    const disputeInfo = key.toBytes32('dispute-info')
+    await deployed.npm.connect(bob).approve(deployed.governance.address, helper.ether(0))
+    await deployed.governance.connect(bob).dispute(coverKey, incidentDate, disputeInfo, helper.ether(0))
+      .should.be.rejectedWith('Stake insufficient')
+
+    // Cleanup - resolve, finalize
+    // Reporting period + 1 second
+    await network.provider.send('evm_increaseTime', [7 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    await deployed.resolution.resolve(coverKey, incidentDate)
+    // Cooldown period + 1 second
+    await network.provider.send('evm_increaseTime', [1 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    // Claim period + 1 second
+    await network.provider.send('evm_increaseTime', [7 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    await deployed.resolution.finalize(coverKey, incidentDate)
+  })
+
+  it('reverts when the value passed as stake is less than the minimum reporting stake', async () => {
+    const [bob] = await ethers.getSigners()
+
+    await deployed.npm.transfer(bob.address, helper.ether(2000))
+
+    const reportingInfo = key.toBytes32('reporting-info')
+    await deployed.npm.approve(deployed.governance.address, helper.ether(1000))
+    await deployed.governance.report(coverKey, reportingInfo, helper.ether(1000))
+
+    const incidentDate = await deployed.governance.getActiveIncidentDate(coverKey)
+
+    const disputeInfo = key.toBytes32('dispute-info')
+    await deployed.npm.connect(bob).approve(deployed.governance.address, helper.ether(25))
+    await deployed.governance.connect(bob).dispute(coverKey, incidentDate, disputeInfo, helper.ether(25))
+      .should.be.rejectedWith('Stake insufficient')
+
+    // Cleanup - resolve, finalize
+    // Reporting period + 1 second
+    await network.provider.send('evm_increaseTime', [7 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    await deployed.resolution.resolve(coverKey, incidentDate)
+    // Cooldown period + 1 second
+    await network.provider.send('evm_increaseTime', [1 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    // Claim period + 1 second
+    await network.provider.send('evm_increaseTime', [7 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    await deployed.resolution.finalize(coverKey, incidentDate)
+  })
+})

--- a/test/specs/governance/emergency-resolve.spec.js
+++ b/test/specs/governance/emergency-resolve.spec.js
@@ -1,0 +1,179 @@
+/* eslint-disable no-unused-expressions */
+const { ethers, network } = require('hardhat')
+const BigNumber = require('bignumber.js')
+const { helper, deployer, key } = require('../../../util')
+const composer = require('../../../util/composer')
+const { deployDependencies } = require('./deps')
+const cache = null
+const DAYS = 86400
+
+require('chai')
+  .use(require('chai-as-promised'))
+  .use(require('chai-bignumber')(BigNumber))
+  .should()
+
+describe('Governance: emergencyResolve', () => {
+  let deployed, coverKey
+
+  before(async () => {
+    const [owner] = await ethers.getSigners()
+    deployed = await deployDependencies()
+
+    deployed.policy = await deployer.deployWithLibraries(cache, 'Policy', {
+      AccessControlLibV1: deployed.accessControlLibV1.address,
+      BaseLibV1: deployed.baseLibV1.address,
+      CoverUtilV1: deployed.coverUtilV1.address,
+      PolicyHelperV1: deployed.policyHelperV1.address,
+      StrategyLibV1: deployed.strategyLibV1.address,
+      ValidationLibV1: deployed.validationLibV1.address
+    }, deployed.store.address)
+
+    await deployed.protocol.addContract(key.PROTOCOL.CNS.COVER_POLICY, deployed.policy.address)
+
+    coverKey = key.toBytes32('foo-bar')
+    const stakeWithFee = helper.ether(10_000)
+    const initialReassuranceAmount = helper.ether(1_000_000)
+    const initialLiquidity = helper.ether(4_000_000)
+    const minReportingStake = helper.ether(250)
+    const reportingPeriod = 7 * DAYS
+    const cooldownPeriod = 1 * DAYS
+    const claimPeriod = 7 * DAYS
+    const floor = helper.percentage(7)
+    const ceiling = helper.percentage(45)
+
+    const requiresWhitelist = false
+    const values = [stakeWithFee, initialReassuranceAmount, minReportingStake, reportingPeriod, cooldownPeriod, claimPeriod, floor, ceiling]
+
+    const info = key.toBytes32('info')
+
+    deployed.cover.updateCoverCreatorWhitelist(owner.address, true)
+
+    await deployed.npm.approve(deployed.stakingContract.address, stakeWithFee)
+    await deployed.dai.approve(deployed.reassuranceContract.address, initialReassuranceAmount)
+
+    await deployed.cover.addCover(coverKey, info, deployed.dai.address, requiresWhitelist, values)
+    await deployed.cover.deployVault(coverKey)
+
+    deployed.vault = await composer.vault.getVault({
+      store: deployed.store,
+      libs: {
+        accessControlLibV1: deployed.accessControlLibV1,
+        baseLibV1: deployed.baseLibV1,
+        transferLib: deployed.transferLib,
+        protoUtilV1: deployed.protoUtilV1,
+        registryLibV1: deployed.registryLibV1,
+        validationLib: deployed.validationLibV1
+      }
+    }, coverKey)
+
+    await deployed.dai.approve(deployed.vault.address, initialLiquidity)
+    await deployed.npm.approve(deployed.vault.address, minReportingStake)
+    await deployed.vault.addLiquidity(coverKey, initialLiquidity, minReportingStake)
+  })
+
+  it('must emergencyResolve correctly', async () => {
+    const [bob] = await ethers.getSigners()
+
+    await deployed.npm.transfer(bob.address, helper.ether(2000))
+
+    const reportingInfo = key.toBytes32('reporting-info')
+    await deployed.npm.approve(deployed.governance.address, helper.ether(1000))
+
+    await deployed.governance.report(coverKey, reportingInfo, helper.ether(1000))
+
+    const incidentDate = await deployed.governance.getActiveIncidentDate(coverKey)
+
+    // Reporting period + 1 second
+    await network.provider.send('evm_increaseTime', [7 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    const tx = await deployed.resolution.emergencyResolve(coverKey, incidentDate, true)
+
+    const { events } = await tx.wait()
+
+    const event = events.find(x => x.event === 'Resolved')
+    event.args.key.should.equal(coverKey)
+    event.args.incidentDate.should.equal(incidentDate)
+    event.args.emergency.should.equal(true)
+    event.args.decision.should.equal(true)
+
+    // Cooldown period + 1 second
+    await network.provider.send('evm_increaseTime', [1 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    // Claim period + 1 second
+    await network.provider.send('evm_increaseTime', [7 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+
+    await deployed.resolution.finalize(coverKey, incidentDate)
+  })
+
+  it('must correctly emergencyResolve when accessed twice', async () => {
+    const [bob] = await ethers.getSigners()
+
+    await deployed.npm.transfer(bob.address, helper.ether(2000))
+
+    const reportingInfo = key.toBytes32('reporting-info')
+    await deployed.npm.approve(deployed.governance.address, helper.ether(1000))
+
+    await deployed.governance.report(coverKey, reportingInfo, helper.ether(1000))
+
+    const incidentDate = await deployed.governance.getActiveIncidentDate(coverKey)
+
+    // Reporting period + 1 second
+    await network.provider.send('evm_increaseTime', [7 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    await deployed.resolution.emergencyResolve(coverKey, incidentDate, true)
+    const tx = await deployed.resolution.emergencyResolve(coverKey, incidentDate, false)
+
+    const { events } = await tx.wait()
+
+    const event = events.find(x => x.event === 'Resolved')
+    event.args.key.should.equal(coverKey)
+    event.args.incidentDate.should.equal(incidentDate)
+    event.args.emergency.should.equal(true)
+    event.args.decision.should.equal(false)
+
+    // Cooldown period + 1 second
+    await network.provider.send('evm_increaseTime', [1 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    // Claim period + 1 second
+    await network.provider.send('evm_increaseTime', [7 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+
+    await deployed.resolution.finalize(coverKey, incidentDate)
+  })
+
+  it('reverts when accessed before reporting period', async () => {
+    const [bob] = await ethers.getSigners()
+
+    await deployed.npm.transfer(bob.address, helper.ether(2000))
+
+    const reportingInfo = key.toBytes32('reporting-info')
+    await deployed.npm.approve(deployed.governance.address, helper.ether(1000))
+
+    await deployed.governance.report(coverKey, reportingInfo, helper.ether(1000))
+
+    const incidentDate = await deployed.governance.getActiveIncidentDate(coverKey)
+
+    await deployed.resolution.emergencyResolve(coverKey, incidentDate, false)
+      .should.be.rejectedWith('Reporting still active')
+
+    // Cleanup - resolve, finalize
+    // Reporting period + 1 second
+    await network.provider.send('evm_increaseTime', [7 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    await deployed.resolution.resolve(coverKey, incidentDate)
+    // Cooldown period + 1 second
+    await network.provider.send('evm_increaseTime', [1 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    // Claim period + 1 second
+    await network.provider.send('evm_increaseTime', [7 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+
+    await deployed.resolution.finalize(coverKey, incidentDate)
+  })
+
+  it('reverts when invalid incident date is specified', async () => {
+    await deployed.resolution.emergencyResolve(coverKey, 0, false)
+      .should.be.rejectedWith('Please specify incident date')
+  })
+})

--- a/test/specs/governance/refute.spec.js
+++ b/test/specs/governance/refute.spec.js
@@ -1,0 +1,213 @@
+/* eslint-disable no-unused-expressions */
+const { ethers, network } = require('hardhat')
+const BigNumber = require('bignumber.js')
+const { helper, deployer, key } = require('../../../util')
+const composer = require('../../../util/composer')
+const { deployDependencies } = require('./deps')
+const cache = null
+const DAYS = 86400
+
+require('chai')
+  .use(require('chai-as-promised'))
+  .use(require('chai-bignumber')(BigNumber))
+  .should()
+
+describe('Governance: refute', () => {
+  let deployed, coverKey
+
+  before(async () => {
+    const [owner] = await ethers.getSigners()
+    deployed = await deployDependencies()
+
+    deployed.policy = await deployer.deployWithLibraries(cache, 'Policy', {
+      AccessControlLibV1: deployed.accessControlLibV1.address,
+      BaseLibV1: deployed.baseLibV1.address,
+      CoverUtilV1: deployed.coverUtilV1.address,
+      PolicyHelperV1: deployed.policyHelperV1.address,
+      StrategyLibV1: deployed.strategyLibV1.address,
+      ValidationLibV1: deployed.validationLibV1.address
+    }, deployed.store.address)
+
+    await deployed.protocol.addContract(key.PROTOCOL.CNS.COVER_POLICY, deployed.policy.address)
+
+    coverKey = key.toBytes32('foo-bar')
+    const stakeWithFee = helper.ether(10_000)
+    const initialReassuranceAmount = helper.ether(1_000_000)
+    const initialLiquidity = helper.ether(4_000_000)
+    const minReportingStake = helper.ether(250)
+    const reportingPeriod = 7 * DAYS
+    const cooldownPeriod = 1 * DAYS
+    const claimPeriod = 7 * DAYS
+    const floor = helper.percentage(7)
+    const ceiling = helper.percentage(45)
+
+    const requiresWhitelist = false
+    const values = [stakeWithFee, initialReassuranceAmount, minReportingStake, reportingPeriod, cooldownPeriod, claimPeriod, floor, ceiling]
+
+    const info = key.toBytes32('info')
+
+    deployed.cover.updateCoverCreatorWhitelist(owner.address, true)
+
+    await deployed.npm.approve(deployed.stakingContract.address, stakeWithFee)
+    await deployed.dai.approve(deployed.reassuranceContract.address, initialReassuranceAmount)
+
+    await deployed.cover.addCover(coverKey, info, deployed.dai.address, requiresWhitelist, values)
+    await deployed.cover.deployVault(coverKey)
+
+    deployed.vault = await composer.vault.getVault({
+      store: deployed.store,
+      libs: {
+        accessControlLibV1: deployed.accessControlLibV1,
+        baseLibV1: deployed.baseLibV1,
+        transferLib: deployed.transferLib,
+        protoUtilV1: deployed.protoUtilV1,
+        registryLibV1: deployed.registryLibV1,
+        validationLib: deployed.validationLibV1
+      }
+    }, coverKey)
+
+    await deployed.dai.approve(deployed.vault.address, initialLiquidity)
+    await deployed.npm.approve(deployed.vault.address, minReportingStake)
+    await deployed.vault.addLiquidity(coverKey, initialLiquidity, minReportingStake)
+  })
+
+  it('must refute correctly', async () => {
+    const [bob] = await ethers.getSigners()
+
+    await deployed.npm.transfer(bob.address, helper.ether(2000))
+
+    const reportingInfo = key.toBytes32('reporting-info')
+    await deployed.npm.approve(deployed.governance.address, helper.ether(1000))
+    await deployed.governance.report(coverKey, reportingInfo, helper.ether(1000))
+
+    const incidentDate = await deployed.governance.getActiveIncidentDate(coverKey)
+
+    const disputeInfo = key.toBytes32('dispute-info')
+    await deployed.npm.connect(bob).approve(deployed.governance.address, helper.ether(1000))
+    await deployed.governance.connect(bob).dispute(coverKey, incidentDate, disputeInfo, helper.ether(1000))
+
+    await deployed.npm.connect(bob).approve(deployed.governance.address, helper.ether(1000))
+    const tx = await deployed.governance.connect(bob).refute(coverKey, incidentDate, helper.ether(1000))
+    const { events } = await tx.wait()
+    const event = events.find(x => x.event === 'Refuted')
+
+    event.args.key.should.equal(coverKey)
+    event.args.incidentDate.should.equal(incidentDate)
+    event.args.witness.should.equal(bob.address)
+    event.args.stake.should.equal(helper.ether(1000))
+
+    // Cleanup - resolve, finalize
+    // Reporting period + 1 second
+    await network.provider.send('evm_increaseTime', [7 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    await deployed.resolution.resolve(coverKey, incidentDate)
+    // Cooldown period + 1 second
+    await network.provider.send('evm_increaseTime', [1 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    // Claim period + 1 second
+    await network.provider.send('evm_increaseTime', [7 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    await deployed.resolution.finalize(coverKey, incidentDate)
+  })
+
+  it('reverts when tried to refute after reporting period', async () => {
+    const [bob] = await ethers.getSigners()
+
+    await deployed.npm.transfer(bob.address, helper.ether(2000))
+
+    const reportingInfo = key.toBytes32('reporting-info')
+    await deployed.npm.approve(deployed.governance.address, helper.ether(1000))
+    await deployed.governance.report(coverKey, reportingInfo, helper.ether(1000))
+
+    const incidentDate = await deployed.governance.getActiveIncidentDate(coverKey)
+
+    const disputeInfo = key.toBytes32('dispute-info')
+    await deployed.npm.connect(bob).approve(deployed.governance.address, helper.ether(1000))
+    await deployed.governance.connect(bob).dispute(coverKey, incidentDate, disputeInfo, helper.ether(1000))
+
+    // Reporting period + 1 second
+    await network.provider.send('evm_increaseTime', [7 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+
+    await deployed.npm.connect(bob).approve(deployed.governance.address, helper.ether(1000))
+    await deployed.governance.connect(bob).refute(coverKey, incidentDate, helper.ether(1000))
+      .should.be.rejectedWith('Reporting window closed')
+
+    // Cleanup - resolve, finalize
+    await deployed.resolution.resolve(coverKey, incidentDate)
+    // Cooldown period + 1 second
+    await network.provider.send('evm_increaseTime', [1 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    // Claim period + 1 second
+    await network.provider.send('evm_increaseTime', [7 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    await deployed.resolution.finalize(coverKey, incidentDate)
+  })
+
+  it('reverts when tried to refute after resolved', async () => {
+    const [bob] = await ethers.getSigners()
+
+    await deployed.npm.transfer(bob.address, helper.ether(2000))
+
+    const reportingInfo = key.toBytes32('reporting-info')
+    await deployed.npm.approve(deployed.governance.address, helper.ether(1000))
+    await deployed.governance.report(coverKey, reportingInfo, helper.ether(1000))
+
+    const incidentDate = await deployed.governance.getActiveIncidentDate(coverKey)
+
+    const disputeInfo = key.toBytes32('dispute-info')
+    await deployed.npm.connect(bob).approve(deployed.governance.address, helper.ether(1000))
+    await deployed.governance.connect(bob).dispute(coverKey, incidentDate, disputeInfo, helper.ether(1000))
+
+    // Reporting period + 1 second
+    await network.provider.send('evm_increaseTime', [7 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    await deployed.resolution.resolve(coverKey, incidentDate)
+
+    await deployed.npm.connect(bob).approve(deployed.governance.address, helper.ether(1000))
+    await deployed.governance.connect(bob).refute(coverKey, incidentDate, helper.ether(1000))
+      .should.be.rejectedWith('Reporting window closed')
+
+    // Cleanup - finalize
+    // Cooldown period + 1 second
+    await network.provider.send('evm_increaseTime', [1 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    // Claim period + 1 second
+    await network.provider.send('evm_increaseTime', [7 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    await deployed.resolution.finalize(coverKey, incidentDate)
+  })
+
+  it('reverts when invalid value is passed as stake', async () => {
+    const [bob] = await ethers.getSigners()
+
+    await deployed.npm.transfer(bob.address, helper.ether(2000))
+
+    const reportingInfo = key.toBytes32('reporting-info')
+    await deployed.npm.approve(deployed.governance.address, helper.ether(1000))
+    await deployed.governance.report(coverKey, reportingInfo, helper.ether(1000))
+
+    const incidentDate = await deployed.governance.getActiveIncidentDate(coverKey)
+
+    const disputeInfo = key.toBytes32('dispute-info')
+    await deployed.npm.connect(bob).approve(deployed.governance.address, helper.ether(1000))
+    await deployed.governance.connect(bob).dispute(coverKey, incidentDate, disputeInfo, helper.ether(1000))
+
+    await deployed.npm.connect(bob).approve(deployed.governance.address, helper.ether(0))
+    await deployed.governance.connect(bob).refute(coverKey, incidentDate, helper.ether(0))
+      .should.be.rejectedWith('Enter a stake')
+
+    // Cleanup - resolve, finalize
+    // Reporting period + 1 second
+    await network.provider.send('evm_increaseTime', [7 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    await deployed.resolution.resolve(coverKey, incidentDate)
+    // Cooldown period + 1 second
+    await network.provider.send('evm_increaseTime', [1 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    // Claim period + 1 second
+    await network.provider.send('evm_increaseTime', [7 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    await deployed.resolution.finalize(coverKey, incidentDate)
+  })
+})

--- a/test/specs/governance/resolution/configure-cool-down-period.spec.js
+++ b/test/specs/governance/resolution/configure-cool-down-period.spec.js
@@ -1,0 +1,133 @@
+/* eslint-disable no-unused-expressions */
+const { ethers, network } = require('hardhat')
+const BigNumber = require('bignumber.js')
+const { helper, deployer, key } = require('../../../../util')
+const composer = require('../../../../util/composer')
+const { deployDependencies } = require('./deps')
+const cache = null
+const DAYS = 86400
+
+require('chai')
+  .use(require('chai-as-promised'))
+  .use(require('chai-bignumber')(BigNumber))
+  .should()
+
+describe('Resolution: configureCoolDownPeriod', () => {
+  let deployed, coverKey
+
+  before(async () => {
+    const [owner] = await ethers.getSigners()
+    deployed = await deployDependencies()
+
+    deployed.policy = await deployer.deployWithLibraries(cache, 'Policy', {
+      AccessControlLibV1: deployed.accessControlLibV1.address,
+      BaseLibV1: deployed.baseLibV1.address,
+      CoverUtilV1: deployed.coverUtilV1.address,
+      PolicyHelperV1: deployed.policyHelperV1.address,
+      StrategyLibV1: deployed.strategyLibV1.address,
+      ValidationLibV1: deployed.validationLibV1.address
+    }, deployed.store.address)
+
+    await deployed.protocol.addContract(key.PROTOCOL.CNS.COVER_POLICY, deployed.policy.address)
+
+    coverKey = key.toBytes32('foo-bar')
+    const stakeWithFee = helper.ether(10_000)
+    const initialReassuranceAmount = helper.ether(1_000_000)
+    const initialLiquidity = helper.ether(4_000_000)
+    const minReportingStake = helper.ether(250)
+    const reportingPeriod = 7 * DAYS
+    const cooldownPeriod = 1 * DAYS
+    const claimPeriod = 7 * DAYS
+    const floor = helper.percentage(7)
+    const ceiling = helper.percentage(45)
+
+    const requiresWhitelist = false
+    const values = [stakeWithFee, initialReassuranceAmount, minReportingStake, reportingPeriod, cooldownPeriod, claimPeriod, floor, ceiling]
+
+    const info = key.toBytes32('info')
+
+    deployed.cover.updateCoverCreatorWhitelist(owner.address, true)
+
+    await deployed.npm.approve(deployed.stakingContract.address, stakeWithFee)
+    await deployed.dai.approve(deployed.reassuranceContract.address, initialReassuranceAmount)
+
+    await deployed.cover.addCover(coverKey, info, deployed.dai.address, requiresWhitelist, values)
+    await deployed.cover.deployVault(coverKey)
+
+    deployed.vault = await composer.vault.getVault({
+      store: deployed.store,
+      libs: {
+        accessControlLibV1: deployed.accessControlLibV1,
+        baseLibV1: deployed.baseLibV1,
+        transferLib: deployed.transferLib,
+        protoUtilV1: deployed.protoUtilV1,
+        registryLibV1: deployed.registryLibV1,
+        validationLib: deployed.validationLibV1
+      }
+    }, coverKey)
+
+    await deployed.dai.approve(deployed.vault.address, initialLiquidity)
+    await deployed.npm.approve(deployed.vault.address, minReportingStake)
+    await deployed.vault.addLiquidity(coverKey, initialLiquidity, minReportingStake)
+  })
+
+  it('must configure cooldown period correctly', async () => {
+    const tx = await deployed.resolution.configureCoolDownPeriod(coverKey, 2.5 * DAYS)
+    const { events } = await tx.wait()
+
+    const event = events.find(x => x.event === 'CooldownPeriodConfigured')
+    event.args.key.should.equal(coverKey)
+    event.args.period.should.equal(2.5 * DAYS)
+
+    const result = await deployed.resolution.getCoolDownPeriod(coverKey)
+    result.should.equal(2.5 * DAYS)
+
+    // Reset
+    await deployed.resolution.configureCoolDownPeriod(coverKey, 1 * DAYS)
+  })
+
+  it('reverts when invalid value is passed as cooldown period', async () => {
+    await deployed.resolution.configureCoolDownPeriod(coverKey, 0)
+      .should.be.rejectedWith('Please specify period')
+  })
+
+  it('reverts when protocol is paused', async () => {
+    await deployed.protocol.pause()
+    await deployed.resolution.configureCoolDownPeriod(coverKey, 0)
+      .should.be.rejectedWith('Protocol is paused')
+    await deployed.protocol.unpause()
+  })
+
+  it('reverts when not accessed by `GOVERNANCE_ADMIN`', async () => {
+    const [, bob] = await ethers.getSigners()
+
+    await deployed.resolution.connect(bob).configureCoolDownPeriod(coverKey, 2.5 * DAYS)
+      .should.be.rejectedWith('Forbidden')
+  })
+
+  it('reverts when cover status is not normal', async () => {
+    const reportingInfo = key.toBytes32('reporting-info')
+    await deployed.npm.approve(deployed.governance.address, helper.ether(1000))
+    await deployed.governance.report(coverKey, reportingInfo, helper.ether(1000))
+
+    await deployed.resolution.configureCoolDownPeriod(coverKey, 0)
+      .should.be.rejectedWith('Status not normal')
+
+    const incidentDate = await deployed.governance.getActiveIncidentDate(coverKey)
+
+    // Reporting period + 1 second
+    await network.provider.send('evm_increaseTime', [7 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    await deployed.resolution.resolve(coverKey, incidentDate)
+
+    // Cooldown period + 1 second
+    await network.provider.send('evm_increaseTime', [1 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+
+    // Claim period + 1 second
+    await network.provider.send('evm_increaseTime', [7 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+
+    await deployed.resolution.finalize(coverKey, incidentDate)
+  })
+})

--- a/test/specs/governance/resolution/deps.js
+++ b/test/specs/governance/resolution/deps.js
@@ -140,7 +140,15 @@ const deployDependencies = async () => {
     ]
   )
 
-  await protocol.grantRoles([{ account: owner.address, roles: [key.ACCESS_CONTROL.UPGRADE_AGENT, key.ACCESS_CONTROL.COVER_MANAGER, key.ACCESS_CONTROL.LIQUIDITY_MANAGER, key.ACCESS_CONTROL.PAUSE_AGENT, key.ACCESS_CONTROL.UNPAUSE_AGENT] }])
+  await protocol.grantRoles([{
+    account: owner.address,
+    roles: [key.ACCESS_CONTROL.UPGRADE_AGENT,
+      key.ACCESS_CONTROL.COVER_MANAGER,
+      key.ACCESS_CONTROL.LIQUIDITY_MANAGER,
+      key.ACCESS_CONTROL.PAUSE_AGENT,
+      key.ACCESS_CONTROL.GOVERNANCE_AGENT,
+      key.ACCESS_CONTROL.UNPAUSE_AGENT]
+  }])
   await protocol.grantRole(key.ACCESS_CONTROL.UPGRADE_AGENT, protocol.address)
 
   const cover = await deployer.deployWithLibraries(cache, 'Cover',

--- a/test/specs/governance/resolution/deps.js
+++ b/test/specs/governance/resolution/deps.js
@@ -147,6 +147,7 @@ const deployDependencies = async () => {
       key.ACCESS_CONTROL.LIQUIDITY_MANAGER,
       key.ACCESS_CONTROL.PAUSE_AGENT,
       key.ACCESS_CONTROL.GOVERNANCE_AGENT,
+      key.ACCESS_CONTROL.GOVERNANCE_ADMIN,
       key.ACCESS_CONTROL.UNPAUSE_AGENT]
   }])
   await protocol.grantRole(key.ACCESS_CONTROL.UPGRADE_AGENT, protocol.address)

--- a/test/specs/governance/resolution/get-cool-down-period.spec.js
+++ b/test/specs/governance/resolution/get-cool-down-period.spec.js
@@ -1,0 +1,78 @@
+/* eslint-disable no-unused-expressions */
+const { ethers } = require('hardhat')
+const BigNumber = require('bignumber.js')
+const { helper, deployer, key } = require('../../../../util')
+const composer = require('../../../../util/composer')
+const { deployDependencies } = require('./deps')
+const cache = null
+const DAYS = 86400
+
+require('chai')
+  .use(require('chai-as-promised'))
+  .use(require('chai-bignumber')(BigNumber))
+  .should()
+
+describe('Resolution: getCoolDownPeriod', () => {
+  let deployed, coverKey
+
+  before(async () => {
+    const [owner] = await ethers.getSigners()
+    deployed = await deployDependencies()
+
+    deployed.policy = await deployer.deployWithLibraries(cache, 'Policy', {
+      AccessControlLibV1: deployed.accessControlLibV1.address,
+      BaseLibV1: deployed.baseLibV1.address,
+      CoverUtilV1: deployed.coverUtilV1.address,
+      PolicyHelperV1: deployed.policyHelperV1.address,
+      StrategyLibV1: deployed.strategyLibV1.address,
+      ValidationLibV1: deployed.validationLibV1.address
+    }, deployed.store.address)
+
+    await deployed.protocol.addContract(key.PROTOCOL.CNS.COVER_POLICY, deployed.policy.address)
+
+    coverKey = key.toBytes32('foo-bar')
+    const stakeWithFee = helper.ether(10_000)
+    const initialReassuranceAmount = helper.ether(1_000_000)
+    const initialLiquidity = helper.ether(4_000_000)
+    const minReportingStake = helper.ether(250)
+    const reportingPeriod = 7 * DAYS
+    const cooldownPeriod = 1 * DAYS
+    const claimPeriod = 7 * DAYS
+    const floor = helper.percentage(7)
+    const ceiling = helper.percentage(45)
+
+    const requiresWhitelist = false
+    const values = [stakeWithFee, initialReassuranceAmount, minReportingStake, reportingPeriod, cooldownPeriod, claimPeriod, floor, ceiling]
+
+    const info = key.toBytes32('info')
+
+    deployed.cover.updateCoverCreatorWhitelist(owner.address, true)
+
+    await deployed.npm.approve(deployed.stakingContract.address, stakeWithFee)
+    await deployed.dai.approve(deployed.reassuranceContract.address, initialReassuranceAmount)
+
+    await deployed.cover.addCover(coverKey, info, deployed.dai.address, requiresWhitelist, values)
+    await deployed.cover.deployVault(coverKey)
+
+    deployed.vault = await composer.vault.getVault({
+      store: deployed.store,
+      libs: {
+        accessControlLibV1: deployed.accessControlLibV1,
+        baseLibV1: deployed.baseLibV1,
+        transferLib: deployed.transferLib,
+        protoUtilV1: deployed.protoUtilV1,
+        registryLibV1: deployed.registryLibV1,
+        validationLib: deployed.validationLibV1
+      }
+    }, coverKey)
+
+    await deployed.dai.approve(deployed.vault.address, initialLiquidity)
+    await deployed.npm.approve(deployed.vault.address, minReportingStake)
+    await deployed.vault.addLiquidity(coverKey, initialLiquidity, minReportingStake)
+  })
+
+  it('must get cooldown period correctly', async () => {
+    const result = await deployed.resolution.getCoolDownPeriod(coverKey)
+    result.should.equal(1 * DAYS)
+  })
+})

--- a/test/specs/governance/resolution/get-resolution-deadline.spec.js
+++ b/test/specs/governance/resolution/get-resolution-deadline.spec.js
@@ -1,0 +1,103 @@
+/* eslint-disable no-unused-expressions */
+const { ethers, network } = require('hardhat')
+const BigNumber = require('bignumber.js')
+const { helper, deployer, key } = require('../../../../util')
+const composer = require('../../../../util/composer')
+const { deployDependencies } = require('./deps')
+const cache = null
+const DAYS = 86400
+
+require('chai')
+  .use(require('chai-as-promised'))
+  .use(require('chai-bignumber')(BigNumber))
+  .should()
+
+describe('Resolution: getResolutionDeadline', () => {
+  let deployed, coverKey
+
+  before(async () => {
+    const [owner] = await ethers.getSigners()
+    deployed = await deployDependencies()
+
+    deployed.policy = await deployer.deployWithLibraries(cache, 'Policy', {
+      AccessControlLibV1: deployed.accessControlLibV1.address,
+      BaseLibV1: deployed.baseLibV1.address,
+      CoverUtilV1: deployed.coverUtilV1.address,
+      PolicyHelperV1: deployed.policyHelperV1.address,
+      StrategyLibV1: deployed.strategyLibV1.address,
+      ValidationLibV1: deployed.validationLibV1.address
+    }, deployed.store.address)
+
+    await deployed.protocol.addContract(key.PROTOCOL.CNS.COVER_POLICY, deployed.policy.address)
+
+    coverKey = key.toBytes32('foo-bar')
+    const stakeWithFee = helper.ether(10_000)
+    const initialReassuranceAmount = helper.ether(1_000_000)
+    const initialLiquidity = helper.ether(4_000_000)
+    const minReportingStake = helper.ether(250)
+    const reportingPeriod = 7 * DAYS
+    const cooldownPeriod = 1 * DAYS
+    const claimPeriod = 7 * DAYS
+    const floor = helper.percentage(7)
+    const ceiling = helper.percentage(45)
+
+    const requiresWhitelist = false
+    const values = [stakeWithFee, initialReassuranceAmount, minReportingStake, reportingPeriod, cooldownPeriod, claimPeriod, floor, ceiling]
+
+    const info = key.toBytes32('info')
+
+    deployed.cover.updateCoverCreatorWhitelist(owner.address, true)
+
+    await deployed.npm.approve(deployed.stakingContract.address, stakeWithFee)
+    await deployed.dai.approve(deployed.reassuranceContract.address, initialReassuranceAmount)
+
+    await deployed.cover.addCover(coverKey, info, deployed.dai.address, requiresWhitelist, values)
+    await deployed.cover.deployVault(coverKey)
+
+    deployed.vault = await composer.vault.getVault({
+      store: deployed.store,
+      libs: {
+        accessControlLibV1: deployed.accessControlLibV1,
+        baseLibV1: deployed.baseLibV1,
+        transferLib: deployed.transferLib,
+        protoUtilV1: deployed.protoUtilV1,
+        registryLibV1: deployed.registryLibV1,
+        validationLib: deployed.validationLibV1
+      }
+    }, coverKey)
+
+    await deployed.dai.approve(deployed.vault.address, initialLiquidity)
+    await deployed.npm.approve(deployed.vault.address, minReportingStake)
+    await deployed.vault.addLiquidity(coverKey, initialLiquidity, minReportingStake)
+  })
+
+  it('must get resolution deadline correctly', async () => {
+    const reportingInfo = key.toBytes32('reporting-info')
+    await deployed.npm.approve(deployed.governance.address, helper.ether(1000))
+    await deployed.governance.report(coverKey, reportingInfo, helper.ether(1000))
+
+    const incidentDate = await deployed.governance.getActiveIncidentDate(coverKey)
+    // Reporting period + 1 second
+    await network.provider.send('evm_increaseTime', [7 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    await deployed.resolution.resolve(coverKey, incidentDate)
+
+    // Reporting period + 1 second + Cooldown period
+    const result = await deployed.resolution.getResolutionDeadline(coverKey)
+    result.should.equal(parseInt(incidentDate, 10) + ((7 * DAYS) + 1) + (1 * DAYS))
+
+    // Clean up - finalize
+    // Cooldown period + 1 second
+    await network.provider.send('evm_increaseTime', [1 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    // Claim period + 1 second
+    await network.provider.send('evm_increaseTime', [7 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    await deployed.resolution.finalize(coverKey, incidentDate)
+  })
+
+  it('must return zero if there is no active reporting', async () => {
+    const result = await deployed.resolution.getResolutionDeadline(coverKey)
+    result.should.equal(0)
+  })
+})

--- a/test/specs/governance/resolution/get-unstake-info-for.spec.js
+++ b/test/specs/governance/resolution/get-unstake-info-for.spec.js
@@ -1,0 +1,86 @@
+/* eslint-disable no-unused-expressions */
+const { ethers } = require('hardhat')
+const BigNumber = require('bignumber.js')
+const { helper, deployer, key } = require('../../../../util')
+const composer = require('../../../../util/composer')
+const { deployDependencies } = require('./deps')
+const cache = null
+const DAYS = 86400
+
+require('chai')
+  .use(require('chai-as-promised'))
+  .use(require('chai-bignumber')(BigNumber))
+  .should()
+
+describe('Resolution: getUnstakeInfoFor', () => {
+  let deployed, coverKey
+
+  before(async () => {
+    const [owner] = await ethers.getSigners()
+    deployed = await deployDependencies()
+
+    deployed.policy = await deployer.deployWithLibraries(cache, 'Policy', {
+      AccessControlLibV1: deployed.accessControlLibV1.address,
+      BaseLibV1: deployed.baseLibV1.address,
+      CoverUtilV1: deployed.coverUtilV1.address,
+      PolicyHelperV1: deployed.policyHelperV1.address,
+      StrategyLibV1: deployed.strategyLibV1.address,
+      ValidationLibV1: deployed.validationLibV1.address
+    }, deployed.store.address)
+
+    await deployed.protocol.addContract(key.PROTOCOL.CNS.COVER_POLICY, deployed.policy.address)
+
+    coverKey = key.toBytes32('foo-bar')
+    const stakeWithFee = helper.ether(10_000)
+    const initialReassuranceAmount = helper.ether(1_000_000)
+    const initialLiquidity = helper.ether(4_000_000)
+    const minReportingStake = helper.ether(250)
+    const reportingPeriod = 7 * DAYS
+    const cooldownPeriod = 1 * DAYS
+    const claimPeriod = 7 * DAYS
+    const floor = helper.percentage(7)
+    const ceiling = helper.percentage(45)
+
+    const requiresWhitelist = false
+    const values = [stakeWithFee, initialReassuranceAmount, minReportingStake, reportingPeriod, cooldownPeriod, claimPeriod, floor, ceiling]
+
+    const info = key.toBytes32('info')
+
+    deployed.cover.updateCoverCreatorWhitelist(owner.address, true)
+
+    await deployed.npm.approve(deployed.stakingContract.address, stakeWithFee)
+    await deployed.dai.approve(deployed.reassuranceContract.address, initialReassuranceAmount)
+
+    await deployed.cover.addCover(coverKey, info, deployed.dai.address, requiresWhitelist, values)
+    await deployed.cover.deployVault(coverKey)
+
+    deployed.vault = await composer.vault.getVault({
+      store: deployed.store,
+      libs: {
+        accessControlLibV1: deployed.accessControlLibV1,
+        baseLibV1: deployed.baseLibV1,
+        transferLib: deployed.transferLib,
+        protoUtilV1: deployed.protoUtilV1,
+        registryLibV1: deployed.registryLibV1,
+        validationLib: deployed.validationLibV1
+      }
+    }, coverKey)
+
+    await deployed.dai.approve(deployed.vault.address, initialLiquidity)
+    await deployed.npm.approve(deployed.vault.address, minReportingStake)
+    await deployed.vault.addLiquidity(coverKey, initialLiquidity, minReportingStake)
+  })
+
+  it('must get unstake info correctly', async () => {
+    const [owner] = await ethers.getSigners()
+
+    const info = key.toBytes32('info')
+    await deployed.npm.approve(deployed.governance.address, helper.ether(1000))
+    await deployed.governance.report(coverKey, info, helper.ether(1000))
+
+    const incidentDate = await deployed.governance.getActiveIncidentDate(coverKey)
+    const result = await deployed.resolution.getUnstakeInfoFor(owner.address, coverKey, incidentDate)
+
+    result.myStakeInWinningCamp.should.equal(helper.ether(1000))
+  })
+})

--- a/test/specs/governance/resolution/unstake-with-claim.spec.js
+++ b/test/specs/governance/resolution/unstake-with-claim.spec.js
@@ -1,0 +1,254 @@
+/* eslint-disable no-unused-expressions */
+const { ethers, network } = require('hardhat')
+const BigNumber = require('bignumber.js')
+const { helper, deployer, key } = require('../../../../util')
+const composer = require('../../../../util/composer')
+const { deployDependencies } = require('./deps')
+const cache = null
+const DAYS = 86400
+
+require('chai')
+  .use(require('chai-as-promised'))
+  .use(require('chai-bignumber')(BigNumber))
+  .should()
+
+describe('Resolution: unstakeWithClaim', () => {
+  let deployed, coverKey
+
+  before(async () => {
+    const [owner] = await ethers.getSigners()
+    deployed = await deployDependencies()
+
+    deployed.policy = await deployer.deployWithLibraries(cache, 'Policy', {
+      AccessControlLibV1: deployed.accessControlLibV1.address,
+      BaseLibV1: deployed.baseLibV1.address,
+      CoverUtilV1: deployed.coverUtilV1.address,
+      PolicyHelperV1: deployed.policyHelperV1.address,
+      StrategyLibV1: deployed.strategyLibV1.address,
+      ValidationLibV1: deployed.validationLibV1.address
+    }, deployed.store.address)
+
+    await deployed.protocol.addContract(key.PROTOCOL.CNS.COVER_POLICY, deployed.policy.address)
+
+    coverKey = key.toBytes32('foo-bar')
+    const stakeWithFee = helper.ether(10_000)
+    const initialReassuranceAmount = helper.ether(1_000_000)
+    const initialLiquidity = helper.ether(4_000_000)
+    const minReportingStake = helper.ether(250)
+    const reportingPeriod = 7 * DAYS
+    const cooldownPeriod = 1 * DAYS
+    const claimPeriod = 7 * DAYS
+    const floor = helper.percentage(7)
+    const ceiling = helper.percentage(45)
+
+    const requiresWhitelist = false
+    const values = [stakeWithFee, initialReassuranceAmount, minReportingStake, reportingPeriod, cooldownPeriod, claimPeriod, floor, ceiling]
+
+    const info = key.toBytes32('info')
+
+    deployed.cover.updateCoverCreatorWhitelist(owner.address, true)
+
+    await deployed.npm.approve(deployed.stakingContract.address, stakeWithFee)
+    await deployed.dai.approve(deployed.reassuranceContract.address, initialReassuranceAmount)
+
+    await deployed.cover.addCover(coverKey, info, deployed.dai.address, requiresWhitelist, values)
+    await deployed.cover.deployVault(coverKey)
+
+    deployed.vault = await composer.vault.getVault({
+      store: deployed.store,
+      libs: {
+        accessControlLibV1: deployed.accessControlLibV1,
+        baseLibV1: deployed.baseLibV1,
+        transferLib: deployed.transferLib,
+        protoUtilV1: deployed.protoUtilV1,
+        registryLibV1: deployed.registryLibV1,
+        validationLib: deployed.validationLibV1
+      }
+    }, coverKey)
+
+    await deployed.dai.approve(deployed.vault.address, initialLiquidity)
+    await deployed.npm.approve(deployed.vault.address, minReportingStake)
+    await deployed.vault.addLiquidity(coverKey, initialLiquidity, minReportingStake)
+  })
+
+  it('must unstake and claim rewards correctly', async () => {
+    const [owner] = await ethers.getSigners()
+
+    const reportingInfo = key.toBytes32('reporting-info')
+    await deployed.npm.approve(deployed.governance.address, helper.ether(1000))
+    await deployed.governance.report(coverKey, reportingInfo, helper.ether(1000))
+
+    const incidentDate = await deployed.governance.getActiveIncidentDate(coverKey)
+
+    // Reporting period + 1 second
+    await network.provider.send('evm_increaseTime', [7 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    await deployed.resolution.resolve(coverKey, incidentDate)
+
+    // Cooldown period + 1 second
+    await network.provider.send('evm_increaseTime', [1 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+
+    const tx = await deployed.resolution.unstakeWithClaim(coverKey, incidentDate)
+    const { events } = await tx.wait()
+
+    const unstakenEvent = events.find(x => x.event === 'Unstaken')
+    unstakenEvent.args.caller.should.equal(owner.address)
+    unstakenEvent.args.originalStake.should.equal(helper.ether(1000))
+    unstakenEvent.args.reward.should.equal(helper.ether(0))
+
+    const reporterRewardDistributedEvent = events.find(x => x.event === 'ReporterRewardDistributed')
+    reporterRewardDistributedEvent.args.caller.should.equal(owner.address)
+    reporterRewardDistributedEvent.args.reporter.should.equal(owner.address)
+    reporterRewardDistributedEvent.args.originalReward.should.equal(helper.ether(0))
+    reporterRewardDistributedEvent.args.reporterReward.should.equal(helper.ether(0))
+
+    const governanceBurnedEvent = events.find(x => x.event === 'GovernanceBurned')
+    governanceBurnedEvent.args.caller.should.equal(owner.address)
+    governanceBurnedEvent.args.burner.should.equal(helper.zero1)
+    governanceBurnedEvent.args.originalReward.should.equal(helper.ether(0))
+    governanceBurnedEvent.args.burnedAmount.should.equal(helper.ether(0))
+
+    // Claim period + 1 second
+    await network.provider.send('evm_increaseTime', [7 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    await deployed.resolution.finalize(coverKey, incidentDate)
+  })
+
+  it('must reverts when accessed after claim period', async () => {
+    const reportingInfo = key.toBytes32('reporting-info')
+    await deployed.npm.approve(deployed.governance.address, helper.ether(1000))
+    await deployed.governance.report(coverKey, reportingInfo, helper.ether(1000))
+
+    const incidentDate = await deployed.governance.getActiveIncidentDate(coverKey)
+
+    // Reporting period + 1 second
+    await network.provider.send('evm_increaseTime', [7 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    await deployed.resolution.resolve(coverKey, incidentDate)
+
+    // Cooldown period + 1 second
+    await network.provider.send('evm_increaseTime', [1 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+
+    // Claim period + 1 second
+    await network.provider.send('evm_increaseTime', [7 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+
+    await deployed.resolution.unstakeWithClaim(coverKey, incidentDate)
+      .should.be.rejectedWith('Claim period has expired')
+
+    await deployed.resolution.finalize(coverKey, incidentDate)
+  })
+
+  it('reverts when accessed before resolved', async () => {
+    const reportingInfo = key.toBytes32('reporting-info')
+    await deployed.npm.approve(deployed.governance.address, helper.ether(1000))
+    await deployed.governance.report(coverKey, reportingInfo, helper.ether(1000))
+
+    const incidentDate = await deployed.governance.getActiveIncidentDate(coverKey)
+
+    // Reporting period + 1 second
+    await network.provider.send('evm_increaseTime', [7 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+
+    // Cooldown period + 1 second
+    await network.provider.send('evm_increaseTime', [1 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+
+    await deployed.resolution.unstakeWithClaim(coverKey, incidentDate)
+      .should.be.rejectedWith('Still unresolved')
+
+    // Clean up - Resolve and finalize
+    // Reporting period + 1 second
+    await network.provider.send('evm_increaseTime', [7 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    await deployed.resolution.resolve(coverKey, incidentDate)
+    // Cooldown period + 1 second
+    await network.provider.send('evm_increaseTime', [1 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    // Claim period + 1 second
+    await network.provider.send('evm_increaseTime', [7 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    await deployed.resolution.finalize(coverKey, incidentDate)
+  })
+
+  it('reverts when accessed after resolved and before emergency resolution deadline', async () => {
+    const reportingInfo = key.toBytes32('reporting-info')
+    await deployed.npm.approve(deployed.governance.address, helper.ether(1000))
+    await deployed.governance.report(coverKey, reportingInfo, helper.ether(1000))
+
+    const incidentDate = await deployed.governance.getActiveIncidentDate(coverKey)
+
+    // Reporting period + 1 second
+    await network.provider.send('evm_increaseTime', [7 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    await deployed.resolution.resolve(coverKey, incidentDate)
+
+    await deployed.resolution.unstakeWithClaim(coverKey, incidentDate)
+      .should.be.rejectedWith('Still unresolved')
+
+    // Clean up - finalize
+    // Cooldown period + 1 second
+    await network.provider.send('evm_increaseTime', [1 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    // Claim period + 1 second
+    await network.provider.send('evm_increaseTime', [7 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    await deployed.resolution.finalize(coverKey, incidentDate)
+  })
+
+  it('reverts when invalid value is passed as incident date', async () => {
+    await deployed.resolution.unstakeWithClaim(coverKey, 0).should.be.rejectedWith('Please specify incident date')
+  })
+
+  it('reverts when protocol is paused', async () => {
+    const reportingInfo = key.toBytes32('reporting-info')
+    await deployed.npm.approve(deployed.governance.address, helper.ether(1000))
+    await deployed.governance.report(coverKey, reportingInfo, helper.ether(1000))
+
+    await deployed.protocol.pause()
+    const incidentDate = await deployed.governance.getActiveIncidentDate(coverKey)
+    await deployed.resolution.unstakeWithClaim(coverKey, incidentDate).should.be.rejectedWith('Protocol is paused')
+
+    // Clean up - Unpause, Resolve and finalize
+    await deployed.protocol.unpause()
+    // Reporting period + 1 second
+    await network.provider.send('evm_increaseTime', [7 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    await deployed.resolution.resolve(coverKey, incidentDate)
+    // Cooldown period + 1 second
+    await network.provider.send('evm_increaseTime', [1 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    // Claim period + 1 second
+    await network.provider.send('evm_increaseTime', [7 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    await deployed.resolution.finalize(coverKey, incidentDate)
+  })
+
+  it('reverts when already unstaken', async () => {
+    const reportingInfo = key.toBytes32('reporting-info')
+    await deployed.npm.approve(deployed.governance.address, helper.ether(1000))
+    await deployed.governance.report(coverKey, reportingInfo, helper.ether(1000))
+
+    const incidentDate = await deployed.governance.getActiveIncidentDate(coverKey)
+
+    // Reporting period + 1 second
+    await network.provider.send('evm_increaseTime', [7 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    await deployed.resolution.resolve(coverKey, incidentDate)
+
+    // Cooldown period + 1 second
+    await network.provider.send('evm_increaseTime', [1 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+
+    await deployed.resolution.unstakeWithClaim(coverKey, incidentDate)
+    await deployed.resolution.unstakeWithClaim(coverKey, incidentDate)
+      .should.be.rejectedWith('Already unstaken')
+
+    // Claim period + 1 second
+    await network.provider.send('evm_increaseTime', [7 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    await deployed.resolution.finalize(coverKey, incidentDate)
+  })
+})

--- a/test/specs/governance/resolution/unstake.spec.js
+++ b/test/specs/governance/resolution/unstake.spec.js
@@ -1,0 +1,215 @@
+/* eslint-disable no-unused-expressions */
+const { ethers, network } = require('hardhat')
+const BigNumber = require('bignumber.js')
+const { helper, deployer, key } = require('../../../../util')
+const composer = require('../../../../util/composer')
+const { deployDependencies } = require('./deps')
+const cache = null
+const DAYS = 86400
+
+require('chai')
+  .use(require('chai-as-promised'))
+  .use(require('chai-bignumber')(BigNumber))
+  .should()
+
+describe('Resolution: unstake', () => {
+  let deployed, coverKey
+
+  before(async () => {
+    const [owner] = await ethers.getSigners()
+    deployed = await deployDependencies()
+
+    deployed.policy = await deployer.deployWithLibraries(cache, 'Policy', {
+      AccessControlLibV1: deployed.accessControlLibV1.address,
+      BaseLibV1: deployed.baseLibV1.address,
+      CoverUtilV1: deployed.coverUtilV1.address,
+      PolicyHelperV1: deployed.policyHelperV1.address,
+      StrategyLibV1: deployed.strategyLibV1.address,
+      ValidationLibV1: deployed.validationLibV1.address
+    }, deployed.store.address)
+
+    await deployed.protocol.addContract(key.PROTOCOL.CNS.COVER_POLICY, deployed.policy.address)
+
+    coverKey = key.toBytes32('foo-bar')
+    const stakeWithFee = helper.ether(10_000)
+    const initialReassuranceAmount = helper.ether(1_000_000)
+    const initialLiquidity = helper.ether(4_000_000)
+    const minReportingStake = helper.ether(250)
+    const reportingPeriod = 7 * DAYS
+    const cooldownPeriod = 1 * DAYS
+    const claimPeriod = 7 * DAYS
+    const floor = helper.percentage(7)
+    const ceiling = helper.percentage(45)
+
+    const requiresWhitelist = false
+    const values = [stakeWithFee, initialReassuranceAmount, minReportingStake, reportingPeriod, cooldownPeriod, claimPeriod, floor, ceiling]
+
+    const info = key.toBytes32('info')
+
+    deployed.cover.updateCoverCreatorWhitelist(owner.address, true)
+
+    await deployed.npm.approve(deployed.stakingContract.address, stakeWithFee)
+    await deployed.dai.approve(deployed.reassuranceContract.address, initialReassuranceAmount)
+
+    await deployed.cover.addCover(coverKey, info, deployed.dai.address, requiresWhitelist, values)
+    await deployed.cover.deployVault(coverKey)
+
+    deployed.vault = await composer.vault.getVault({
+      store: deployed.store,
+      libs: {
+        accessControlLibV1: deployed.accessControlLibV1,
+        baseLibV1: deployed.baseLibV1,
+        transferLib: deployed.transferLib,
+        protoUtilV1: deployed.protoUtilV1,
+        registryLibV1: deployed.registryLibV1,
+        validationLib: deployed.validationLibV1
+      }
+    }, coverKey)
+
+    await deployed.dai.approve(deployed.vault.address, initialLiquidity)
+    await deployed.npm.approve(deployed.vault.address, minReportingStake)
+    await deployed.vault.addLiquidity(coverKey, initialLiquidity, minReportingStake)
+  })
+
+  it('must unstake correctly', async () => {
+    const [owner] = await ethers.getSigners()
+
+    const reportingInfo = key.toBytes32('reporting-info')
+    await deployed.npm.approve(deployed.governance.address, helper.ether(1000))
+    await deployed.governance.report(coverKey, reportingInfo, helper.ether(1000))
+
+    const incidentDate = await deployed.governance.getActiveIncidentDate(coverKey)
+
+    // Reporting period + 1 second
+    await network.provider.send('evm_increaseTime', [7 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    await deployed.resolution.resolve(coverKey, incidentDate)
+
+    // Cooldown period + 1 second
+    await network.provider.send('evm_increaseTime', [1 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+
+    const tx = await deployed.resolution.unstake(coverKey, incidentDate)
+    const { events } = await tx.wait()
+    const event = events.find(x => x.event === 'Unstaken')
+
+    event.args.caller.should.equal(owner.address)
+    event.args.originalStake.should.equal(helper.ether(1000))
+
+    // Claim period + 1 second
+    await network.provider.send('evm_increaseTime', [7 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    await deployed.resolution.finalize(coverKey, incidentDate)
+  })
+
+  it('reverts when accessed before resolved', async () => {
+    const reportingInfo = key.toBytes32('reporting-info')
+    await deployed.npm.approve(deployed.governance.address, helper.ether(1000))
+    await deployed.governance.report(coverKey, reportingInfo, helper.ether(1000))
+
+    const incidentDate = await deployed.governance.getActiveIncidentDate(coverKey)
+
+    // Reporting period + 1 second
+    await network.provider.send('evm_increaseTime', [7 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+
+    // Cooldown period + 1 second
+    await network.provider.send('evm_increaseTime', [1 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+
+    await deployed.resolution.unstake(coverKey, incidentDate)
+      .should.be.rejectedWith('Still unresolved')
+
+    // Clean up - Resolve and finalize
+    // Reporting period + 1 second
+    await network.provider.send('evm_increaseTime', [7 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    await deployed.resolution.resolve(coverKey, incidentDate)
+    // Cooldown period + 1 second
+    await network.provider.send('evm_increaseTime', [1 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    // Claim period + 1 second
+    await network.provider.send('evm_increaseTime', [7 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    await deployed.resolution.finalize(coverKey, incidentDate)
+  })
+
+  it('reverts when accessed after resolved and before emergency resolution deadline', async () => {
+    const reportingInfo = key.toBytes32('reporting-info')
+    await deployed.npm.approve(deployed.governance.address, helper.ether(1000))
+    await deployed.governance.report(coverKey, reportingInfo, helper.ether(1000))
+
+    const incidentDate = await deployed.governance.getActiveIncidentDate(coverKey)
+
+    // Reporting period + 1 second
+    await network.provider.send('evm_increaseTime', [7 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    await deployed.resolution.resolve(coverKey, incidentDate)
+
+    await deployed.resolution.unstake(coverKey, incidentDate)
+      .should.be.rejectedWith('Still unresolved')
+
+    // Clean up - finalize
+    // Cooldown period + 1 second
+    await network.provider.send('evm_increaseTime', [1 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    // Claim period + 1 second
+    await network.provider.send('evm_increaseTime', [7 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    await deployed.resolution.finalize(coverKey, incidentDate)
+  })
+
+  it('reverts when invalid value is passed as incident date', async () => {
+    await deployed.resolution.unstake(coverKey, 0).should.be.rejectedWith('Please specify incident date')
+  })
+
+  it('reverts when protocol is paused', async () => {
+    const reportingInfo = key.toBytes32('reporting-info')
+    await deployed.npm.approve(deployed.governance.address, helper.ether(1000))
+    await deployed.governance.report(coverKey, reportingInfo, helper.ether(1000))
+
+    await deployed.protocol.pause()
+    const incidentDate = await deployed.governance.getActiveIncidentDate(coverKey)
+    await deployed.resolution.unstake(coverKey, incidentDate).should.be.rejectedWith('Protocol is paused')
+
+    // Clean up - Unpause, Resolve and finalize
+    await deployed.protocol.unpause()
+    // Reporting period + 1 second
+    await network.provider.send('evm_increaseTime', [7 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    await deployed.resolution.resolve(coverKey, incidentDate)
+    // Cooldown period + 1 second
+    await network.provider.send('evm_increaseTime', [1 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    // Claim period + 1 second
+    await network.provider.send('evm_increaseTime', [7 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    await deployed.resolution.finalize(coverKey, incidentDate)
+  })
+
+  it('reverts when already unstaken', async () => {
+    const reportingInfo = key.toBytes32('reporting-info')
+    await deployed.npm.approve(deployed.governance.address, helper.ether(1000))
+    await deployed.governance.report(coverKey, reportingInfo, helper.ether(1000))
+
+    const incidentDate = await deployed.governance.getActiveIncidentDate(coverKey)
+
+    // Reporting period + 1 second
+    await network.provider.send('evm_increaseTime', [7 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    await deployed.resolution.resolve(coverKey, incidentDate)
+
+    // Cooldown period + 1 second
+    await network.provider.send('evm_increaseTime', [1 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+
+    await deployed.resolution.unstake(coverKey, incidentDate)
+    await deployed.resolution.unstake(coverKey, incidentDate)
+      .should.be.rejectedWith('Already unstaken')
+
+    // Claim period + 1 second
+    await network.provider.send('evm_increaseTime', [7 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    await deployed.resolution.finalize(coverKey, incidentDate)
+  })
+})

--- a/test/specs/governance/resolve.spec.js
+++ b/test/specs/governance/resolve.spec.js
@@ -1,0 +1,171 @@
+/* eslint-disable no-unused-expressions */
+const { ethers, network } = require('hardhat')
+const BigNumber = require('bignumber.js')
+const { helper, deployer, key } = require('../../../util')
+const composer = require('../../../util/composer')
+const { deployDependencies } = require('./deps')
+const cache = null
+const DAYS = 86400
+
+require('chai')
+  .use(require('chai-as-promised'))
+  .use(require('chai-bignumber')(BigNumber))
+  .should()
+
+describe('Governance: resolve', () => {
+  let deployed, coverKey
+
+  before(async () => {
+    const [owner] = await ethers.getSigners()
+    deployed = await deployDependencies()
+
+    deployed.policy = await deployer.deployWithLibraries(cache, 'Policy', {
+      AccessControlLibV1: deployed.accessControlLibV1.address,
+      BaseLibV1: deployed.baseLibV1.address,
+      CoverUtilV1: deployed.coverUtilV1.address,
+      PolicyHelperV1: deployed.policyHelperV1.address,
+      StrategyLibV1: deployed.strategyLibV1.address,
+      ValidationLibV1: deployed.validationLibV1.address
+    }, deployed.store.address)
+
+    await deployed.protocol.addContract(key.PROTOCOL.CNS.COVER_POLICY, deployed.policy.address)
+
+    coverKey = key.toBytes32('foo-bar')
+    const stakeWithFee = helper.ether(10_000)
+    const initialReassuranceAmount = helper.ether(1_000_000)
+    const initialLiquidity = helper.ether(4_000_000)
+    const minReportingStake = helper.ether(250)
+    const reportingPeriod = 7 * DAYS
+    const cooldownPeriod = 1 * DAYS
+    const claimPeriod = 7 * DAYS
+    const floor = helper.percentage(7)
+    const ceiling = helper.percentage(45)
+
+    const requiresWhitelist = false
+    const values = [stakeWithFee, initialReassuranceAmount, minReportingStake, reportingPeriod, cooldownPeriod, claimPeriod, floor, ceiling]
+
+    const info = key.toBytes32('info')
+
+    deployed.cover.updateCoverCreatorWhitelist(owner.address, true)
+
+    await deployed.npm.approve(deployed.stakingContract.address, stakeWithFee)
+    await deployed.dai.approve(deployed.reassuranceContract.address, initialReassuranceAmount)
+
+    await deployed.cover.addCover(coverKey, info, deployed.dai.address, requiresWhitelist, values)
+    await deployed.cover.deployVault(coverKey)
+
+    deployed.vault = await composer.vault.getVault({
+      store: deployed.store,
+      libs: {
+        accessControlLibV1: deployed.accessControlLibV1,
+        baseLibV1: deployed.baseLibV1,
+        transferLib: deployed.transferLib,
+        protoUtilV1: deployed.protoUtilV1,
+        registryLibV1: deployed.registryLibV1,
+        validationLib: deployed.validationLibV1
+      }
+    }, coverKey)
+
+    await deployed.dai.approve(deployed.vault.address, initialLiquidity)
+    await deployed.npm.approve(deployed.vault.address, minReportingStake)
+    await deployed.vault.addLiquidity(coverKey, initialLiquidity, minReportingStake)
+  })
+
+  it('must resolve correctly', async () => {
+    const [bob] = await ethers.getSigners()
+
+    await deployed.npm.transfer(bob.address, helper.ether(2000))
+
+    const reportingInfo = key.toBytes32('reporting-info')
+    await deployed.npm.approve(deployed.governance.address, helper.ether(1000))
+
+    await deployed.governance.report(coverKey, reportingInfo, helper.ether(1000))
+
+    const incidentDate = await deployed.governance.getActiveIncidentDate(coverKey)
+
+    // Reporting period + 1 second
+    await network.provider.send('evm_increaseTime', [7 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    const tx = await deployed.resolution.resolve(coverKey, incidentDate)
+
+    const { events } = await tx.wait()
+
+    const event = events.find(x => x.event === 'Resolved')
+    event.args.key.should.equal(coverKey)
+    event.args.incidentDate.should.equal(incidentDate)
+    event.args.emergency.should.equal(false)
+
+    // Cooldown period + 1 second
+    await network.provider.send('evm_increaseTime', [1 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    // Claim period + 1 second
+    await network.provider.send('evm_increaseTime', [7 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+
+    await deployed.resolution.finalize(coverKey, incidentDate)
+  })
+
+  it('reverts when accessed twice', async () => {
+    const [bob] = await ethers.getSigners()
+
+    await deployed.npm.transfer(bob.address, helper.ether(2000))
+
+    const reportingInfo = key.toBytes32('reporting-info')
+    await deployed.npm.approve(deployed.governance.address, helper.ether(1000))
+
+    await deployed.governance.report(coverKey, reportingInfo, helper.ether(1000))
+
+    const incidentDate = await deployed.governance.getActiveIncidentDate(coverKey)
+
+    // Reporting period + 1 second
+    await network.provider.send('evm_increaseTime', [7 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    await deployed.resolution.resolve(coverKey, incidentDate)
+    await deployed.resolution.resolve(coverKey, incidentDate)
+      .should.be.rejectedWith('Not reported nor disputed')
+
+    // Cooldown period + 1 second
+    await network.provider.send('evm_increaseTime', [1 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    // Claim period + 1 second
+    await network.provider.send('evm_increaseTime', [7 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+
+    await deployed.resolution.finalize(coverKey, incidentDate)
+  })
+
+  it('reverts when accessed before reporting period', async () => {
+    const [bob] = await ethers.getSigners()
+
+    await deployed.npm.transfer(bob.address, helper.ether(2000))
+
+    const reportingInfo = key.toBytes32('reporting-info')
+    await deployed.npm.approve(deployed.governance.address, helper.ether(1000))
+
+    await deployed.governance.report(coverKey, reportingInfo, helper.ether(1000))
+
+    const incidentDate = await deployed.governance.getActiveIncidentDate(coverKey)
+
+    await deployed.resolution.resolve(coverKey, incidentDate)
+      .should.be.rejectedWith('Reporting still active')
+
+    // Cleanup - resolve, finalize
+    // Reporting period + 1 second
+    await network.provider.send('evm_increaseTime', [7 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    await deployed.resolution.resolve(coverKey, incidentDate)
+    // Cooldown period + 1 second
+    await network.provider.send('evm_increaseTime', [1 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+    // Claim period + 1 second
+    await network.provider.send('evm_increaseTime', [7 * DAYS])
+    await network.provider.send('evm_increaseTime', [1])
+
+    await deployed.resolution.finalize(coverKey, incidentDate)
+  })
+
+  it('reverts when invalid incident date is specified', async () => {
+    await deployed.resolution.resolve(coverKey, 0)
+      .should.be.rejectedWith('Please specify incident date')
+  })
+})


### PR DESCRIPTION
- Fixed a bug in governance `unstake` feature which allows user to invoke `unstake` even before the incident resolved.
- Fixed a bug in governance `unstakeWithClaim` feature which allows user to invoke `unstakeWithClaim` even after the claim period is ended (before finalized).
- Added tests for the above fixes.