### PR TITLE
Liquidity Tests

### DIFF
--- a/contracts/core/delegates/VaultDelegateBase.sol
+++ b/contracts/core/delegates/VaultDelegateBase.sol
@@ -95,7 +95,7 @@ abstract contract VaultDelegateBase is IVaultDelegate, Recoverable {
     IERC20, /*token*/
     bytes32 coverKey,
     bytes32 strategyName,
-    uint256 amount
+    uint256 /*amount*/
   ) external override nonReentrant {
     s.mustNotBePaused();
     s.senderMustBeVaultContract(coverKey);

--- a/contracts/core/liquidity/LiquidityEngine.sol
+++ b/contracts/core/liquidity/LiquidityEngine.sol
@@ -64,6 +64,10 @@ contract LiquidityEngine is ILiquidityEngine, Recoverable {
     s.setLendingPeriodsInternal(0, lendingPeriod, withdrawalWindow);
   }
 
+  function getLendingPeriods(bytes32 coverKey) external view override returns (uint256 lendingPeriod, uint256 withdrawalWindow) {
+    return s.getLendingPeriodsInternal(coverKey);
+  }
+
   function getDisabledStrategies() external view override returns (address[] memory strategies) {
     return s.getDisabledStrategiesInternal();
   }

--- a/contracts/core/liquidity/strategies/AaveStrategy.sol
+++ b/contracts/core/liquidity/strategies/AaveStrategy.sol
@@ -154,6 +154,8 @@ contract AaveStrategy is ILendingStrategy, Recoverable {
     // Check how many DAI we received
     stablecoinWithdrawn = stablecoin.balanceOf(address(this));
 
+    require(stablecoinWithdrawn > 0, "Redeeming aToken failed");
+
     // Immediately send DAI to the vault aToken came from
     stablecoin.ensureApproval(address(vault), stablecoinWithdrawn);
     vault.receiveFromStrategy(stablecoin, coverKey, getName(), stablecoinWithdrawn);
@@ -177,7 +179,7 @@ contract AaveStrategy is ILendingStrategy, Recoverable {
     return keccak256(abi.encodePacked(_KEY, coverKey, NS_WITHDRAWALS));
   }
 
-  function getWeight() external pure override returns (uint256) {
+  function getWeight() external pure virtual override returns (uint256) {
     return 10_000; // 100%
   }
 

--- a/contracts/core/liquidity/strategies/CompoundStrategy.sol
+++ b/contracts/core/liquidity/strategies/CompoundStrategy.sol
@@ -156,6 +156,8 @@ contract CompoundStrategy is ILendingStrategy, Recoverable {
     // Check how many DAI we received
     stablecoinWithdrawn = stablecoin.balanceOf(address(this));
 
+    require(stablecoinWithdrawn > 0, "Redeeming cDai failed");
+
     // Immediately send DAI to the vault cDAI came from
     stablecoin.ensureApproval(address(vault), stablecoinWithdrawn);
     vault.receiveFromStrategy(stablecoin, coverKey, getName(), stablecoinWithdrawn);

--- a/contracts/fakes/FakeCompoundDaiDelegator.sol
+++ b/contracts/fakes/FakeCompoundDaiDelegator.sol
@@ -1,0 +1,48 @@
+// Neptune Mutual Protocol (https://neptunemutual.com)
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.0;
+import "../interfaces/external/ICompoundERC20DelegatorLike.sol";
+import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
+import "./FakeToken.sol";
+
+contract FakeCompoundDaiDelegator is ICompoundERC20DelegatorLike, ERC20 {
+  FakeToken public dai;
+  FakeToken public cDai;
+
+  constructor(FakeToken _dai, FakeToken _cDai) ERC20("cDAI", "cDAI") {
+    dai = _dai;
+    cDai = _cDai;
+  }
+
+  /**
+   * @notice Sender supplies assets into the market and receives cTokens in exchange
+   * @dev Accrues interest whether or not the operation succeeds, unless reverted
+   * @param mintAmount The amount of the underlying asset to supply
+   * @return uint 0=success, otherwise a failure (see ErrorReporter.sol for details)
+   */
+  function mint(uint256 mintAmount) external override returns (uint256) {
+    dai.transferFrom(msg.sender, address(this), mintAmount);
+
+    cDai.mint(mintAmount);
+    cDai.transfer(msg.sender, mintAmount);
+
+    return 0;
+  }
+
+  /**
+   * @notice Sender redeems cTokens in exchange for the underlying asset
+   * @dev Accrues interest whether or not the operation succeeds, unless reverted
+   * @param redeemTokens The number of cTokens to redeem into underlying
+   * @return uint 0=success, otherwise a failure (see ErrorReporter.sol for details)
+   */
+  function redeem(uint256 redeemTokens) external override returns (uint256) {
+    cDai.transferFrom(msg.sender, address(this), redeemTokens);
+
+    uint256 interest = (redeemTokens * 3) / 100;
+    dai.mint(interest);
+
+    dai.transfer(msg.sender, redeemTokens + interest);
+
+    return 0;
+  }
+}

--- a/contracts/fakes/FaultyAaveLendingPool.sol
+++ b/contracts/fakes/FaultyAaveLendingPool.sol
@@ -1,0 +1,32 @@
+// Neptune Mutual Protocol (https://neptunemutual.com)
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.0;
+import "../interfaces/external/IAaveV2LendingPoolLike.sol";
+import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
+import "./FakeToken.sol";
+
+contract FaultyAaveLendingPool is IAaveV2LendingPoolLike, ERC20 {
+  FakeToken public aToken;
+
+  constructor(FakeToken _aToken) ERC20("aDAI", "aDAI") {
+    aToken = _aToken;
+  }
+
+  function deposit(
+    address asset,
+    uint256 amount,
+    address,
+    uint16
+  ) external override {
+    IERC20(asset).transferFrom(msg.sender, address(this), amount);
+  }
+
+  function withdraw(
+    address, /*asset*/
+    uint256 amount,
+    address /*to*/
+  ) external override returns (uint256) {
+    aToken.transferFrom(msg.sender, address(this), amount);
+    return amount;
+  }
+}

--- a/contracts/fakes/FaultyCompoundDaiDelegator.sol
+++ b/contracts/fakes/FaultyCompoundDaiDelegator.sol
@@ -5,13 +5,23 @@ import "../interfaces/external/ICompoundERC20DelegatorLike.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
 import "./FakeToken.sol";
 
-contract FakeCompoundERC20Delegator is ICompoundERC20DelegatorLike, ERC20 {
+contract FaultyCompoundDaiDelegator is ICompoundERC20DelegatorLike, ERC20 {
   FakeToken public dai;
   FakeToken public cDai;
+  uint256 public returnValue;
 
-  constructor(FakeToken _dai, FakeToken _cDai) ERC20("cDAI", "cDAI") {
+  function setReturnValue(uint256 _returnValue) external {
+    returnValue = _returnValue;
+  }
+
+  constructor(
+    FakeToken _dai,
+    FakeToken _cDai,
+    uint256 _returnValue
+  ) ERC20("cDAI", "cDAI") {
     dai = _dai;
     cDai = _cDai;
+    returnValue = _returnValue;
   }
 
   /**
@@ -22,11 +32,7 @@ contract FakeCompoundERC20Delegator is ICompoundERC20DelegatorLike, ERC20 {
    */
   function mint(uint256 mintAmount) external override returns (uint256) {
     dai.transferFrom(msg.sender, address(this), mintAmount);
-
-    cDai.mint(mintAmount);
-    cDai.transfer(msg.sender, mintAmount);
-
-    return 0;
+    return returnValue;
   }
 
   /**
@@ -37,12 +43,6 @@ contract FakeCompoundERC20Delegator is ICompoundERC20DelegatorLike, ERC20 {
    */
   function redeem(uint256 redeemTokens) external override returns (uint256) {
     cDai.transferFrom(msg.sender, address(this), redeemTokens);
-
-    uint256 interest = (redeemTokens * 3) / 100;
-    dai.mint(interest);
-
-    dai.transfer(msg.sender, redeemTokens + interest);
-
-    return 0;
+    return returnValue;
   }
 }

--- a/contracts/fakes/InvalidStrategy.sol
+++ b/contracts/fakes/InvalidStrategy.sol
@@ -1,0 +1,17 @@
+// Neptune Mutual Protocol (https://neptunemutual.com)
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.0;
+
+import "../core/liquidity/strategies/AaveStrategy.sol";
+
+contract InvalidStrategy is AaveStrategy {
+  constructor(
+    IStore _s,
+    IAaveV2LendingPoolLike _lendingPool,
+    address _aToken
+  ) AaveStrategy(_s, _lendingPool, _aToken) {} // solhint-disable-line
+
+  function getWeight() external pure override returns (uint256) {
+    return 20_000; // 100%
+  }
+}

--- a/contracts/interfaces/ILiquidityEngine.sol
+++ b/contracts/interfaces/ILiquidityEngine.sol
@@ -23,6 +23,8 @@ interface ILiquidityEngine is IMember {
 
   function setLendingPeriodsDefault(uint256 lendingPeriod, uint256 withdrawalWindow) external;
 
+  function getLendingPeriods(bytes32 coverKey) external view returns (uint256 lendingPeriod, uint256 withdrawalWindow);
+
   function setLiquidityStateUpdateInterval(uint256 value) external;
 
   function getDisabledStrategies() external view returns (address[] memory strategies);

--- a/contracts/libraries/PriceLibV1.sol
+++ b/contracts/libraries/PriceLibV1.sol
@@ -90,12 +90,12 @@ library PriceLibV1 {
     return (2 * reserve1 * lpTokens) / supply;
   }
 
-  function getLastUpdateOnInternal(IStore s) public view returns (uint256) {
+  function getLastUpdateOnInternal(IStore s) external view returns (uint256) {
     bytes32 key = getLastUpdateKey();
     return s.getUintByKey(key);
   }
 
-  function setLastUpdateOn(IStore s) public {
+  function setLastUpdateOn(IStore s) external {
     bytes32 key = getLastUpdateKey();
     s.setUintByKey(key, block.timestamp); // solhint-disable-line
   }

--- a/contracts/libraries/StrategyLibV1.sol
+++ b/contracts/libraries/StrategyLibV1.sol
@@ -38,12 +38,12 @@ library StrategyLibV1 {
   }
 
   function getLendingPeriodsInternal(IStore s, bytes32 coverKey) external view returns (uint256 lendingPeriod, uint256 withdrawalWindow) {
-    lendingPeriod = s.getUintByKey(getLendingPeriodKey(coverKey, true));
-    withdrawalWindow = s.getUintByKey(getWithdrawalWindowKey(coverKey, true));
+    lendingPeriod = s.getUintByKey(getLendingPeriodKey(coverKey));
+    withdrawalWindow = s.getUintByKey(getWithdrawalWindowKey(coverKey));
 
     if (lendingPeriod == 0) {
-      lendingPeriod = s.getUintByKey(getLendingPeriodKey(0, true));
-      withdrawalWindow = s.getUintByKey(getWithdrawalWindowKey(0, true));
+      lendingPeriod = s.getUintByKey(getLendingPeriodKey(0));
+      withdrawalWindow = s.getUintByKey(getWithdrawalWindowKey(0));
     }
   }
 
@@ -53,17 +53,13 @@ library StrategyLibV1 {
     uint256 lendingPeriod,
     uint256 withdrawalWindow
   ) external {
-    s.setUintByKey(getLendingPeriodKey(coverKey, true), lendingPeriod);
-    s.setUintByKey(getWithdrawalWindowKey(coverKey, true), withdrawalWindow);
+    s.setUintByKey(getLendingPeriodKey(coverKey), lendingPeriod);
+    s.setUintByKey(getWithdrawalWindowKey(coverKey), withdrawalWindow);
 
     emit LendingPeriodSet(lendingPeriod, withdrawalWindow);
   }
 
-  function getLendingPeriodKey(bytes32 coverKey, bool ignoreMissingKey) public pure returns (bytes32) {
-    if (ignoreMissingKey == false) {
-      require(coverKey > 0, "Invalid Cover Key");
-    }
-
+  function getLendingPeriodKey(bytes32 coverKey) public pure returns (bytes32) {
     if (coverKey > 0) {
       return keccak256(abi.encodePacked(ProtoUtilV1.NS_COVER_LIQUIDITY_LENDING_PERIOD, coverKey));
     }
@@ -71,11 +67,7 @@ library StrategyLibV1 {
     return ProtoUtilV1.NS_COVER_LIQUIDITY_LENDING_PERIOD;
   }
 
-  function getWithdrawalWindowKey(bytes32 coverKey, bool ignoreMissingKey) public pure returns (bytes32) {
-    if (ignoreMissingKey == false) {
-      require(coverKey > 0, "Invalid Cover Key");
-    }
-
+  function getWithdrawalWindowKey(bytes32 coverKey) public pure returns (bytes32) {
     if (coverKey > 0) {
       return keccak256(abi.encodePacked(ProtoUtilV1.NS_COVER_LIQUIDITY_WITHDRAWAL_WINDOW, coverKey));
     }

--- a/test/specs/liquidity/engine/add-strategies.spec.js
+++ b/test/specs/liquidity/engine/add-strategies.spec.js
@@ -117,6 +117,25 @@ describe('Liquidity Engine: addStrategies', () => {
     await liquidityEngine.connect(bob).addStrategies([aaveStrategy.address]).should.be.rejectedWith('Forbidden')
   })
 
+  it('reverts when too much weight is specified', async () => {
+    const aToken = await deployer.deploy(cache, 'FakeToken', 'Neptune Mutual Token', 'NPM', helper.ether(100_000_000))
+
+    const aaveLendingPool = await deployer.deploy(cache, 'FakeAaveLendingPool', aToken.address)
+
+    const invalidStrategy = await deployer.deployWithLibraries(cache, 'InvalidStrategy', {
+      AccessControlLibV1: accessControlLibV1.address,
+      BaseLibV1: baseLibV1.address,
+      NTransferUtilV2: transferLib.address,
+      ProtoUtilV1: protoUtilV1.address,
+      RegistryLibV1: registryLibV1.address,
+      StoreKeyUtil: storeKeyUtil.address,
+      ValidationLibV1: validationLibV1.address
+    }, store.address, aaveLendingPool.address, aToken.address)
+
+    await deployed.protocol.addContract(key.PROTOCOL.CNS.STRATEGY_AAVE, invalidStrategy.address)
+    await liquidityEngine.addStrategies([invalidStrategy.address]).should.be.rejectedWith('Weight too much')
+  })
+
   it('reverts when protocol is paused', async () => {
     const aToken = await deployer.deploy(cache, 'FakeToken', 'Neptune Mutual Token', 'NPM', helper.ether(100_000_000))
 

--- a/test/specs/liquidity/engine/disable-strategy.spec.js
+++ b/test/specs/liquidity/engine/disable-strategy.spec.js
@@ -75,6 +75,11 @@ describe('Liquidity Engine: disableStrategy', () => {
     event.args.strategy.should.equal(aaveStrategy.address)
   })
 
+  it('must throw while disabling an invalid strategy', async () => {
+    await liquidityEngine.disableStrategy(helper.randomAddress())
+      .should.be.rejectedWith('Invalid strategy')
+  })
+
   it('correctly get disabled strategies', async () => {
     await liquidityEngine.disableStrategy(aaveStrategy.address)
     const disabledStrategies = await liquidityEngine.getDisabledStrategies()

--- a/test/specs/liquidity/engine/set-lending-periods-default.spec.js
+++ b/test/specs/liquidity/engine/set-lending-periods-default.spec.js
@@ -51,6 +51,10 @@ describe('Liquidity Engine: `setLendingPeriodsDefault` function', () => {
 
     event.args.lendingPeriod.should.equal(lendingPeriod)
     event.args.withdrawalWindow.should.equal(withdrawalWindow)
+
+    const result = await liquidityEngine.getLendingPeriods(key.toBytes32(''))
+    result[0].should.equal(lendingPeriod)
+    result[1].should.equal(withdrawalWindow)
   })
 
   it('reverts when protocol is paused', async () => {

--- a/test/specs/liquidity/engine/set-lending-periods.spec.js
+++ b/test/specs/liquidity/engine/set-lending-periods.spec.js
@@ -41,6 +41,12 @@ describe('Liquidity Engine: `setLendingPeriods` function', () => {
     await deployed.protocol.addContract(key.PROTOCOL.CNS.LIQUIDITY_ENGINE, liquidityEngine.address)
   })
 
+  it('correct gets the lending period', async () => {
+    const result = await liquidityEngine.getLendingPeriods(coverkey)
+    result[0].should.equal('0')
+    result[1].should.equal('0')
+  })
+
   it('correctly sets lending period', async () => {
     const lendingPeriod = '10'
     const withdrawalWindow = '10'
@@ -52,6 +58,10 @@ describe('Liquidity Engine: `setLendingPeriods` function', () => {
 
     event.args.lendingPeriod.should.equal(lendingPeriod)
     event.args.withdrawalWindow.should.equal(withdrawalWindow)
+
+    const result = await liquidityEngine.getLendingPeriods(coverkey)
+    result[0].should.equal(lendingPeriod)
+    result[1].should.equal(withdrawalWindow)
   })
 
   it('reverts when protocol is paused', async () => {

--- a/test/specs/liquidity/strategy/aave/ctor.spec.js
+++ b/test/specs/liquidity/strategy/aave/ctor.spec.js
@@ -1,0 +1,37 @@
+/* eslint-disable no-unused-expressions */
+const BigNumber = require('bignumber.js')
+const { deployer, key, helper } = require('../../../../../util')
+const { deployDependencies } = require('../deps')
+const cache = null
+
+require('chai')
+  .use(require('chai-as-promised'))
+  .use(require('chai-bignumber')(BigNumber))
+  .should()
+
+describe('Aave Strategy Constructor', () => {
+  let deployed, aaveLendingPool, aToken
+
+  beforeEach(async () => {
+    deployed = await deployDependencies()
+
+    aToken = await deployer.deploy(cache, 'FakeToken', 'aToken', 'aToken', helper.ether(100_000_000))
+    aaveLendingPool = await deployer.deploy(cache, 'FakeAaveLendingPool', aToken.address)
+  })
+
+  it('correctly deploys', async () => {
+    const aaveStrategy = await deployer.deployWithLibraries(cache, 'AaveStrategy', {
+      AccessControlLibV1: deployed.accessControlLibV1.address,
+      BaseLibV1: deployed.baseLibV1.address,
+      NTransferUtilV2: deployed.transferLib.address,
+      ProtoUtilV1: deployed.protoUtilV1.address,
+      RegistryLibV1: deployed.registryLibV1.address,
+      StoreKeyUtil: deployed.storeKeyUtil.address,
+      ValidationLibV1: deployed.validationLibV1.address
+    }, deployed.store.address, aaveLendingPool.address, aToken.address)
+
+   ; (await aaveStrategy.getKey()).should.equal(ethers.utils.solidityKeccak256(['string', 'string', 'string', 'string'], ['lending', 'strategy', 'aave', 'v2']))
+    ; (await aaveStrategy.version()).should.equal(key.toBytes32('v0.1'))
+    ; (await aaveStrategy.getName()).should.equal(key.PROTOCOL.CNAME.STRATEGY_AAVE)
+  })
+})

--- a/test/specs/liquidity/strategy/aave/deposit.spec.js
+++ b/test/specs/liquidity/strategy/aave/deposit.spec.js
@@ -1,0 +1,90 @@
+/* eslint-disable no-unused-expressions */
+const BigNumber = require('bignumber.js')
+const { deployer, key, helper } = require('../../../../../util')
+const { deployDependencies } = require('../deps')
+const cache = null
+
+require('chai')
+  .use(require('chai-as-promised'))
+  .use(require('chai-bignumber')(BigNumber))
+  .should()
+
+describe('Aave Deposit', () => {
+  let deployed, aaveLendingPool, aToken, aaveStrategy
+
+  beforeEach(async () => {
+    deployed = await deployDependencies()
+
+    aToken = await deployer.deploy(cache, 'FakeToken', 'aToken', 'aToken', helper.ether(100_000_000))
+    aaveLendingPool = await deployer.deploy(cache, 'FakeAaveLendingPool', aToken.address)
+
+    aaveStrategy = await deployer.deployWithLibraries(cache, 'AaveStrategy', {
+      AccessControlLibV1: deployed.accessControlLibV1.address,
+      BaseLibV1: deployed.baseLibV1.address,
+      NTransferUtilV2: deployed.transferLib.address,
+      ProtoUtilV1: deployed.protoUtilV1.address,
+      RegistryLibV1: deployed.registryLibV1.address,
+      StoreKeyUtil: deployed.storeKeyUtil.address,
+      ValidationLibV1: deployed.validationLibV1.address
+    }, deployed.store.address, aaveLendingPool.address, aToken.address)
+
+    await deployed.protocol.addContract(key.PROTOCOL.CNS.STRATEGY_AAVE, aaveStrategy.address)
+
+    await deployed.liquidityEngine.addStrategies([aaveStrategy.address])
+  })
+
+  it('must correctly deposit', async () => {
+    const amount = helper.ether(10)
+    const tx = await aaveStrategy.deposit(deployed.coverKey, amount)
+    const { events } = await tx.wait()
+    const event = events.find(x => x.event === 'Deposited')
+
+    event.args.key.should.equal(deployed.coverKey)
+    event.args.onBehalfOf.should.equal(deployed.vault.address)
+    event.args.stablecoinDeposited.should.equal(amount)
+    event.args.certificateTokenIssued.should.be.gte(amount)
+
+    const [deposited] = await aaveStrategy.getInfo(deployed.coverKey)
+    deposited.should.equal(amount)
+  })
+
+  it('must return zero if zero amount is deposited', async () => {
+    const value = await aaveStrategy.callStatic.deposit(deployed.coverKey, '0')
+    value.should.equal('0')
+  })
+
+  it('must revert if deposit amount exceeds vault balance', async () => {
+    await aaveStrategy.deposit(deployed.coverKey, helper.ether(240_000_000))
+      .should.be.rejectedWith('Balance insufficient')
+  })
+})
+
+describe('Aave Deposit: Faulty Pool', () => {
+  let deployed, aaveLendingPool, aToken, aaveStrategy
+
+  beforeEach(async () => {
+    deployed = await deployDependencies()
+
+    aToken = await deployer.deploy(cache, 'FakeToken', 'aToken', 'aToken', helper.ether(100_000_000))
+    aaveLendingPool = await deployer.deploy(cache, 'FaultyAaveLendingPool', aToken.address)
+
+    aaveStrategy = await deployer.deployWithLibraries(cache, 'AaveStrategy', {
+      AccessControlLibV1: deployed.accessControlLibV1.address,
+      BaseLibV1: deployed.baseLibV1.address,
+      NTransferUtilV2: deployed.transferLib.address,
+      ProtoUtilV1: deployed.protoUtilV1.address,
+      RegistryLibV1: deployed.registryLibV1.address,
+      StoreKeyUtil: deployed.storeKeyUtil.address,
+      ValidationLibV1: deployed.validationLibV1.address
+    }, deployed.store.address, aaveLendingPool.address, aToken.address)
+
+    await deployed.protocol.addContract(key.PROTOCOL.CNS.STRATEGY_AAVE, aaveStrategy.address)
+
+    await deployed.liquidityEngine.addStrategies([aaveStrategy.address])
+  })
+
+  it('must revert if no certificate tokens were received', async () => {
+    await aaveStrategy.deposit(deployed.coverKey, helper.ether(10))
+      .should.be.rejectedWith('Deposit to Aave failed')
+  })
+})

--- a/test/specs/liquidity/strategy/aave/drain.spec.js
+++ b/test/specs/liquidity/strategy/aave/drain.spec.js
@@ -1,0 +1,47 @@
+/* eslint-disable no-unused-expressions */
+const BigNumber = require('bignumber.js')
+const { deployer, key, helper } = require('../../../../../util')
+const { deployDependencies } = require('../deps')
+const cache = null
+
+require('chai')
+  .use(require('chai-as-promised'))
+  .use(require('chai-bignumber')(BigNumber))
+  .should()
+
+describe('Aave Deposit: Drained', () => {
+  let deployed, aaveLendingPool, aToken, aaveStrategy
+
+  beforeEach(async () => {
+    deployed = await deployDependencies()
+
+    aToken = await deployer.deploy(cache, 'FakeToken', 'aToken', 'aToken', helper.ether(100_000_000))
+    aaveLendingPool = await deployer.deploy(cache, 'FakeAaveLendingPool', aToken.address)
+
+    aaveStrategy = await deployer.deployWithLibraries(cache, 'AaveStrategy', {
+      AccessControlLibV1: deployed.accessControlLibV1.address,
+      BaseLibV1: deployed.baseLibV1.address,
+      NTransferUtilV2: deployed.transferLib.address,
+      ProtoUtilV1: deployed.protoUtilV1.address,
+      RegistryLibV1: deployed.registryLibV1.address,
+      StoreKeyUtil: deployed.storeKeyUtil.address,
+      ValidationLibV1: deployed.validationLibV1.address
+    }, deployed.store.address, aaveLendingPool.address, aToken.address)
+
+    await deployed.protocol.addContract(key.PROTOCOL.CNS.STRATEGY_AAVE, aaveStrategy.address)
+
+    await deployed.liquidityEngine.addStrategies([aaveStrategy.address])
+  })
+
+  it('must correctly drain', async () => {
+    await deployed.dai.transfer(aaveStrategy.address, helper.ether(100))
+
+    const amount = helper.ether(10)
+    const tx = await aaveStrategy.deposit(deployed.coverKey, amount)
+    const { events } = await tx.wait()
+    const event = events.find(x => x.event === 'Drained')
+
+    event.args.asset.should.equal(deployed.dai.address)
+    event.args.amount.should.equal(helper.ether(100))
+  })
+})

--- a/test/specs/liquidity/strategy/aave/withdraw.spec.js
+++ b/test/specs/liquidity/strategy/aave/withdraw.spec.js
@@ -1,0 +1,90 @@
+/* eslint-disable no-unused-expressions */
+const BigNumber = require('bignumber.js')
+const { deployer, key, helper } = require('../../../../../util')
+const { deployDependencies } = require('../deps')
+const cache = null
+
+require('chai')
+  .use(require('chai-as-promised'))
+  .use(require('chai-bignumber')(BigNumber))
+  .should()
+
+describe('Aave Withdrawal', () => {
+  let deployed, aaveLendingPool, aToken, aaveStrategy
+
+  beforeEach(async () => {
+    deployed = await deployDependencies()
+
+    aToken = await deployer.deploy(cache, 'FakeToken', 'aToken', 'aToken', helper.ether(100_000_000))
+    aaveLendingPool = await deployer.deploy(cache, 'FakeAaveLendingPool', aToken.address)
+
+    aaveStrategy = await deployer.deployWithLibraries(cache, 'AaveStrategy', {
+      AccessControlLibV1: deployed.accessControlLibV1.address,
+      BaseLibV1: deployed.baseLibV1.address,
+      NTransferUtilV2: deployed.transferLib.address,
+      ProtoUtilV1: deployed.protoUtilV1.address,
+      RegistryLibV1: deployed.registryLibV1.address,
+      StoreKeyUtil: deployed.storeKeyUtil.address,
+      ValidationLibV1: deployed.validationLibV1.address
+    }, deployed.store.address, aaveLendingPool.address, aToken.address)
+
+    await deployed.protocol.addContract(key.PROTOCOL.CNS.STRATEGY_AAVE, aaveStrategy.address)
+
+    await deployed.liquidityEngine.addStrategies([aaveStrategy.address])
+  })
+
+  it('must correctly withdraw', async () => {
+    const amount = helper.ether(10)
+    await aaveStrategy.deposit(deployed.coverKey, amount)
+
+    const aTokens = await aToken.balanceOf(deployed.vault.address)
+    const tx = await aaveStrategy.withdraw(deployed.coverKey)
+    const { events } = await tx.wait()
+    const event = events.find(x => x.event === 'Withdrawn')
+
+    event.args.key.should.equal(deployed.coverKey)
+    event.args.sendTo.should.equal(deployed.vault.address)
+    event.args.stablecoinWithdrawn.should.be.gte(amount)
+    event.args.certificateTokenRedeemed.should.equal(aTokens.toString())
+
+    const [, withdrawn] = await aaveStrategy.getInfo(deployed.coverKey)
+    withdrawn.should.equal(event.args.stablecoinWithdrawn)
+  })
+
+  it('must return zero if value has no balance', async () => {
+    const result = await aaveStrategy.callStatic.withdraw(deployed.coverKey)
+    result.should.equal('0')
+  })
+})
+
+describe('Aave Deposit: Faulty Pool', () => {
+  let deployed, aaveLendingPool, aToken, aaveStrategy
+
+  beforeEach(async () => {
+    deployed = await deployDependencies()
+
+    aToken = await deployer.deploy(cache, 'FakeToken', 'aToken', 'aToken', helper.ether(100_000_000))
+    aaveLendingPool = await deployer.deploy(cache, 'FaultyAaveLendingPool', aToken.address)
+
+    await aToken.transfer(deployed.vault.address, helper.ether(1000))
+
+    aaveStrategy = await deployer.deployWithLibraries(cache, 'AaveStrategy', {
+      AccessControlLibV1: deployed.accessControlLibV1.address,
+      BaseLibV1: deployed.baseLibV1.address,
+      NTransferUtilV2: deployed.transferLib.address,
+      ProtoUtilV1: deployed.protoUtilV1.address,
+      RegistryLibV1: deployed.registryLibV1.address,
+      StoreKeyUtil: deployed.storeKeyUtil.address,
+      ValidationLibV1: deployed.validationLibV1.address
+    }, deployed.store.address, aaveLendingPool.address, aToken.address)
+
+    await deployed.protocol.addContract(key.PROTOCOL.CNS.STRATEGY_AAVE, aaveStrategy.address)
+
+    await deployed.liquidityEngine.addStrategies([aaveStrategy.address])
+  })
+
+  it('must revert if no stablecoins were received', async () => {
+    await aaveStrategy.withdraw(deployed.coverKey)
+      .should.be.rejectedWith('Redeeming aToken failed')
+  })
+})

--- a/test/specs/liquidity/strategy/compound/ctor.spec.js
+++ b/test/specs/liquidity/strategy/compound/ctor.spec.js
@@ -1,0 +1,37 @@
+/* eslint-disable no-unused-expressions */
+const BigNumber = require('bignumber.js')
+const { deployer, key, helper } = require('../../../../../util')
+const { deployDependencies } = require('../deps')
+const cache = null
+
+require('chai')
+  .use(require('chai-as-promised'))
+  .use(require('chai-bignumber')(BigNumber))
+  .should()
+
+describe('Compound Strategy Constructor', () => {
+  let deployed, daiDelegator, cDai
+
+  beforeEach(async () => {
+    deployed = await deployDependencies()
+
+    cDai = await deployer.deploy(cache, 'FakeToken', 'cDai', 'cDai', helper.ether(100_000_000))
+    daiDelegator = await deployer.deploy(cache, 'FakeCompoundDaiDelegator', deployed.dai.address, cDai.address)
+  })
+
+  it('correctly deploys', async () => {
+    const compoundStrategy = await deployer.deployWithLibraries(cache, 'CompoundStrategy', {
+      AccessControlLibV1: deployed.accessControlLibV1.address,
+      BaseLibV1: deployed.baseLibV1.address,
+      NTransferUtilV2: deployed.transferLib.address,
+      ProtoUtilV1: deployed.protoUtilV1.address,
+      RegistryLibV1: deployed.registryLibV1.address,
+      StoreKeyUtil: deployed.storeKeyUtil.address,
+      ValidationLibV1: deployed.validationLibV1.address
+    }, deployed.store.address, daiDelegator.address, cDai.address)
+
+   ; (await compoundStrategy.getKey()).should.equal(ethers.utils.solidityKeccak256(['string', 'string', 'string', 'string'], ['lending', 'strategy', 'compound', 'v2']))
+    ; (await compoundStrategy.version()).should.equal(key.toBytes32('v0.1'))
+    ; (await compoundStrategy.getName()).should.equal(key.PROTOCOL.CNAME.STRATEGY_COMPOUND)
+  })
+})

--- a/test/specs/liquidity/strategy/compound/deposit.spec.js
+++ b/test/specs/liquidity/strategy/compound/deposit.spec.js
@@ -1,0 +1,97 @@
+/* eslint-disable no-unused-expressions */
+const BigNumber = require('bignumber.js')
+const { deployer, key, helper } = require('../../../../../util')
+const { deployDependencies } = require('../deps')
+const cache = null
+
+require('chai')
+  .use(require('chai-as-promised'))
+  .use(require('chai-bignumber')(BigNumber))
+  .should()
+
+describe('Compound Deposit', () => {
+  let deployed, daiDelegator, cDai, compoundStrategy
+
+  beforeEach(async () => {
+    deployed = await deployDependencies()
+
+    cDai = await deployer.deploy(cache, 'FakeToken', 'cDai', 'cDai', helper.ether(100_000_000))
+    daiDelegator = await deployer.deploy(cache, 'FakeCompoundDaiDelegator', deployed.dai.address, cDai.address)
+
+    compoundStrategy = await deployer.deployWithLibraries(cache, 'CompoundStrategy', {
+      AccessControlLibV1: deployed.accessControlLibV1.address,
+      BaseLibV1: deployed.baseLibV1.address,
+      NTransferUtilV2: deployed.transferLib.address,
+      ProtoUtilV1: deployed.protoUtilV1.address,
+      RegistryLibV1: deployed.registryLibV1.address,
+      StoreKeyUtil: deployed.storeKeyUtil.address,
+      ValidationLibV1: deployed.validationLibV1.address
+    }, deployed.store.address, daiDelegator.address, cDai.address)
+
+    await deployed.protocol.addContract(key.PROTOCOL.CNS.STRATEGY_COMPOUND, compoundStrategy.address)
+
+    await deployed.liquidityEngine.addStrategies([compoundStrategy.address])
+  })
+
+  it('must correctly deposit', async () => {
+    const amount = helper.ether(10)
+    const tx = await compoundStrategy.deposit(deployed.coverKey, amount)
+    const { events } = await tx.wait()
+    const event = events.find(x => x.event === 'Deposited')
+
+    event.args.key.should.equal(deployed.coverKey)
+    event.args.onBehalfOf.should.equal(deployed.vault.address)
+    event.args.stablecoinDeposited.should.equal(amount)
+    event.args.certificateTokenIssued.should.be.gte(amount)
+
+    const [deposited] = await compoundStrategy.getInfo(deployed.coverKey)
+    deposited.should.equal(amount)
+  })
+
+  it('must return zero if zero amount is deposited', async () => {
+    const value = await compoundStrategy.callStatic.deposit(deployed.coverKey, '0')
+    value.should.equal('0')
+  })
+
+  it('must revert if deposit amount exceeds vault balance', async () => {
+    await compoundStrategy.deposit(deployed.coverKey, helper.ether(240_000_000))
+      .should.be.rejectedWith('Balance insufficient')
+  })
+})
+
+describe('Compound Deposit: Faulty Pool', () => {
+  let deployed, daiDelegator, compoundStrategy
+
+  before(async () => {
+    deployed = await deployDependencies()
+    const cDai = await deployer.deploy(cache, 'FakeToken', 'cDai', 'cDai', helper.ether(100_000_000))
+
+    daiDelegator = await deployer.deploy(cache, 'FaultyCompoundDaiDelegator', deployed.dai.address, cDai.address, '1')
+
+    compoundStrategy = await deployer.deployWithLibraries(cache, 'CompoundStrategy', {
+      AccessControlLibV1: deployed.accessControlLibV1.address,
+      BaseLibV1: deployed.baseLibV1.address,
+      NTransferUtilV2: deployed.transferLib.address,
+      ProtoUtilV1: deployed.protoUtilV1.address,
+      RegistryLibV1: deployed.registryLibV1.address,
+      StoreKeyUtil: deployed.storeKeyUtil.address,
+      ValidationLibV1: deployed.validationLibV1.address
+    }, deployed.store.address, daiDelegator.address, cDai.address)
+
+    await deployed.protocol.addContract(key.PROTOCOL.CNS.STRATEGY_COMPOUND, compoundStrategy.address)
+
+    await deployed.liquidityEngine.addStrategies([compoundStrategy.address])
+  })
+
+  it('must revert if dai delegator returns an error code', async () => {
+    await compoundStrategy.deposit(deployed.coverKey, helper.ether(10))
+      .should.be.rejectedWith('Compound delegator mint failed')
+  })
+
+  it('must revert if no certificate tokens were received', async () => {
+    await daiDelegator.setReturnValue('0')
+
+    await compoundStrategy.deposit(deployed.coverKey, helper.ether(10))
+      .should.be.rejectedWith('Minting cDai failed')
+  })
+})

--- a/test/specs/liquidity/strategy/compound/drain.spec.js
+++ b/test/specs/liquidity/strategy/compound/drain.spec.js
@@ -1,0 +1,47 @@
+/* eslint-disable no-unused-expressions */
+const BigNumber = require('bignumber.js')
+const { deployer, key, helper } = require('../../../../../util')
+const { deployDependencies } = require('../deps')
+const cache = null
+
+require('chai')
+  .use(require('chai-as-promised'))
+  .use(require('chai-bignumber')(BigNumber))
+  .should()
+
+describe('Compound Deposit: Drained', () => {
+  let deployed, daiDelegator, cDai, compoundStrategy
+
+  beforeEach(async () => {
+    deployed = await deployDependencies()
+
+    cDai = await deployer.deploy(cache, 'FakeToken', 'cDai', 'cDai', helper.ether(100_000_000))
+    daiDelegator = await deployer.deploy(cache, 'FakeCompoundDaiDelegator', deployed.dai.address, cDai.address)
+
+    compoundStrategy = await deployer.deployWithLibraries(cache, 'CompoundStrategy', {
+      AccessControlLibV1: deployed.accessControlLibV1.address,
+      BaseLibV1: deployed.baseLibV1.address,
+      NTransferUtilV2: deployed.transferLib.address,
+      ProtoUtilV1: deployed.protoUtilV1.address,
+      RegistryLibV1: deployed.registryLibV1.address,
+      StoreKeyUtil: deployed.storeKeyUtil.address,
+      ValidationLibV1: deployed.validationLibV1.address
+    }, deployed.store.address, daiDelegator.address, cDai.address)
+
+    await deployed.protocol.addContract(key.PROTOCOL.CNS.STRATEGY_COMPOUND, compoundStrategy.address)
+
+    await deployed.liquidityEngine.addStrategies([compoundStrategy.address])
+  })
+
+  it('must correctly drain', async () => {
+    await deployed.dai.transfer(compoundStrategy.address, helper.ether(100))
+
+    const amount = helper.ether(10)
+    const tx = await compoundStrategy.deposit(deployed.coverKey, amount)
+    const { events } = await tx.wait()
+    const event = events.find(x => x.event === 'Drained')
+
+    event.args.asset.should.equal(deployed.dai.address)
+    event.args.amount.should.equal(helper.ether(100))
+  })
+})

--- a/test/specs/liquidity/strategy/compound/withdraw.spec.js
+++ b/test/specs/liquidity/strategy/compound/withdraw.spec.js
@@ -1,0 +1,95 @@
+/* eslint-disable no-unused-expressions */
+const BigNumber = require('bignumber.js')
+const { deployer, key, helper } = require('../../../../../util')
+const { deployDependencies } = require('../deps')
+const cache = null
+
+require('chai')
+  .use(require('chai-as-promised'))
+  .use(require('chai-bignumber')(BigNumber))
+  .should()
+
+describe('Compound Withdrawal', () => {
+  let deployed, daiDelegator, cDai, compoundStrategy
+
+  beforeEach(async () => {
+    deployed = await deployDependencies()
+
+    cDai = await deployer.deploy(cache, 'FakeToken', 'cDai', 'cDai', helper.ether(100_000_000))
+    daiDelegator = await deployer.deploy(cache, 'FakeCompoundDaiDelegator', deployed.dai.address, cDai.address)
+
+    compoundStrategy = await deployer.deployWithLibraries(cache, 'CompoundStrategy', {
+      AccessControlLibV1: deployed.accessControlLibV1.address,
+      BaseLibV1: deployed.baseLibV1.address,
+      NTransferUtilV2: deployed.transferLib.address,
+      ProtoUtilV1: deployed.protoUtilV1.address,
+      RegistryLibV1: deployed.registryLibV1.address,
+      StoreKeyUtil: deployed.storeKeyUtil.address,
+      ValidationLibV1: deployed.validationLibV1.address
+    }, deployed.store.address, daiDelegator.address, cDai.address)
+
+    await deployed.protocol.addContract(key.PROTOCOL.CNS.STRATEGY_COMPOUND, compoundStrategy.address)
+
+    await deployed.liquidityEngine.addStrategies([compoundStrategy.address])
+  })
+
+  it('must correctly withdraw', async () => {
+    const amount = helper.ether(10)
+    await compoundStrategy.deposit(deployed.coverKey, amount)
+
+    const cDais = await cDai.balanceOf(deployed.vault.address)
+    const tx = await compoundStrategy.withdraw(deployed.coverKey)
+    const { events } = await tx.wait()
+    const event = events.find(x => x.event === 'Withdrawn')
+
+    event.args.key.should.equal(deployed.coverKey)
+    event.args.sendTo.should.equal(deployed.vault.address)
+    event.args.stablecoinWithdrawn.should.be.gte(amount)
+    event.args.certificateTokenRedeemed.should.equal(cDais.toString())
+
+    const [, withdrawn] = await compoundStrategy.getInfo(deployed.coverKey)
+    withdrawn.should.equal(event.args.stablecoinWithdrawn)
+  })
+
+  it('must return zero if value has no balance', async () => {
+    const result = await compoundStrategy.callStatic.withdraw(deployed.coverKey)
+    result.should.equal('0')
+  })
+})
+
+describe('Compound Withdrawal: Faulty Pool', () => {
+  let deployed, daiDelegator, compoundStrategy
+
+  before(async () => {
+    deployed = await deployDependencies()
+    const cDai = await deployer.deploy(cache, 'FakeToken', 'cDai', 'cDai', helper.ether(100_000_000))
+    daiDelegator = await deployer.deploy(cache, 'FaultyCompoundDaiDelegator', deployed.dai.address, cDai.address, '1')
+
+    await cDai.transfer(deployed.vault.address, helper.ether(1000))
+
+    compoundStrategy = await deployer.deployWithLibraries(cache, 'CompoundStrategy', {
+      AccessControlLibV1: deployed.accessControlLibV1.address,
+      BaseLibV1: deployed.baseLibV1.address,
+      NTransferUtilV2: deployed.transferLib.address,
+      ProtoUtilV1: deployed.protoUtilV1.address,
+      RegistryLibV1: deployed.registryLibV1.address,
+      StoreKeyUtil: deployed.storeKeyUtil.address,
+      ValidationLibV1: deployed.validationLibV1.address
+    }, deployed.store.address, daiDelegator.address, cDai.address)
+
+    await deployed.protocol.addContract(key.PROTOCOL.CNS.STRATEGY_COMPOUND, compoundStrategy.address)
+    await deployed.liquidityEngine.addStrategies([compoundStrategy.address])
+  })
+
+  it('must revert if dai delegator returns an error code', async () => {
+    await compoundStrategy.withdraw(deployed.coverKey)
+      .should.be.rejectedWith('Compound delegator redeem failed')
+  })
+
+  it('must revert if no certificate tokens were received', async () => {
+    await daiDelegator.setReturnValue('0')
+
+    await compoundStrategy.withdraw(deployed.coverKey)
+      .should.be.rejectedWith('Redeeming cDai failed')
+  })
+})

--- a/test/specs/liquidity/strategy/deps.js
+++ b/test/specs/liquidity/strategy/deps.js
@@ -1,0 +1,389 @@
+/* eslint-disable no-unused-expressions */
+const { helper, deployer, key } = require('../../../../util')
+const pair = require('../../../../util/composer/uniswap-pair')
+const composer = require('../../../../util/composer')
+
+const DAYS = 86400
+const cache = null
+
+const deployDependencies = async () => {
+  const [owner] = await ethers.getSigners()
+  const store = await deployer.deploy(cache, 'Store')
+  const router = await deployer.deploy(cache, 'FakeUniswapV2RouterLike')
+
+  const npm = await deployer.deploy(cache, 'FakeToken', 'Neptune Mutual Token', 'NPM', helper.ether(100_000_000))
+  const dai = await deployer.deploy(cache, 'FakeToken', 'DAI', 'DAI', helper.ether(100_000_000))
+  const [[npmDai]] = await pair.deploySeveral(cache, [{ token0: npm.address, token1: dai.address }])
+
+  const factory = await deployer.deploy(cache, 'FakeUniswapV2FactoryLike', npmDai.address)
+  const storeKeyUtil = await deployer.deploy(cache, 'StoreKeyUtil')
+
+  const protoUtilV1 = await deployer.deployWithLibraries(cache, 'ProtoUtilV1', {
+    StoreKeyUtil: storeKeyUtil.address
+  })
+
+  const accessControlLibV1 = await deployer.deployWithLibraries(cache, 'AccessControlLibV1', {
+    ProtoUtilV1: protoUtilV1.address,
+    StoreKeyUtil: storeKeyUtil.address
+  })
+
+  const registryLibV1 = await deployer.deployWithLibraries(cache, 'RegistryLibV1', {
+    ProtoUtilV1: protoUtilV1.address,
+    StoreKeyUtil: storeKeyUtil.address
+  })
+
+  const strategyLibV1 = await deployer.deployWithLibraries(cache, 'StrategyLibV1', {
+    ProtoUtilV1: protoUtilV1.address,
+    RegistryLibV1: registryLibV1.address,
+    StoreKeyUtil: storeKeyUtil.address
+  })
+
+  const coverUtilV1 = await deployer.deployWithLibraries(cache, 'CoverUtilV1', {
+    RegistryLibV1: registryLibV1.address,
+    StrategyLibV1: strategyLibV1.address,
+    ProtoUtilV1: protoUtilV1.address,
+    StoreKeyUtil: storeKeyUtil.address
+  })
+
+  const priceLibV1 = await deployer.deployWithLibraries(cache, 'PriceLibV1', {
+    ProtoUtilV1: protoUtilV1.address,
+    StoreKeyUtil: storeKeyUtil.address
+  })
+
+  const routineInvokerLibV1 = await deployer.deployWithLibraries(cache, 'RoutineInvokerLibV1', {
+    CoverUtilV1: coverUtilV1.address,
+    PriceLibV1: priceLibV1.address,
+    ProtoUtilV1: protoUtilV1.address,
+    RegistryLibV1: registryLibV1.address,
+    StrategyLibV1: strategyLibV1.address,
+    StoreKeyUtil: storeKeyUtil.address
+  })
+
+  const governanceUtilV1 = await deployer.deployWithLibraries(cache, 'GovernanceUtilV1', {
+    CoverUtilV1: coverUtilV1.address,
+    RoutineInvokerLibV1: routineInvokerLibV1.address,
+    StoreKeyUtil: storeKeyUtil.address
+  })
+
+  const validationLibV1 = await deployer.deployWithLibraries(cache, 'ValidationLibV1', {
+    AccessControlLibV1: accessControlLibV1.address,
+    CoverUtilV1: coverUtilV1.address,
+    GovernanceUtilV1: governanceUtilV1.address,
+    ProtoUtilV1: protoUtilV1.address,
+    RegistryLibV1: registryLibV1.address,
+    StoreKeyUtil: storeKeyUtil.address
+  })
+
+  const transferLib = await deployer.deploy(cache, 'NTransferUtilV2')
+
+  const baseLibV1 = await deployer.deployWithLibraries(cache, 'BaseLibV1', {
+  })
+
+  const coverLibV1 = await deployer.deployWithLibraries(cache, 'CoverLibV1', {
+    AccessControlLibV1: accessControlLibV1.address,
+    CoverUtilV1: coverUtilV1.address,
+    RoutineInvokerLibV1: routineInvokerLibV1.address,
+    NTransferUtilV2: transferLib.address,
+    ProtoUtilV1: protoUtilV1.address,
+    RegistryLibV1: registryLibV1.address,
+    StrategyLibV1: strategyLibV1.address,
+    StoreKeyUtil: storeKeyUtil.address,
+    ValidationLibV1: validationLibV1.address
+  })
+
+  const policyHelperV1 = await deployer.deployWithLibraries(cache, 'PolicyHelperV1', {
+    CoverUtilV1: coverUtilV1.address,
+    NTransferUtilV2: transferLib.address,
+    ProtoUtilV1: protoUtilV1.address,
+    RegistryLibV1: registryLibV1.address,
+    RoutineInvokerLibV1: routineInvokerLibV1.address,
+    StoreKeyUtil: storeKeyUtil.address
+  })
+
+  const protocol = await deployer.deployWithLibraries(cache, 'Protocol',
+    {
+      AccessControlLibV1: accessControlLibV1.address,
+      BaseLibV1: baseLibV1.address,
+      ProtoUtilV1: protoUtilV1.address,
+      RegistryLibV1: registryLibV1.address,
+      StoreKeyUtil: storeKeyUtil.address,
+      ValidationLibV1: validationLibV1.address
+    },
+    store.address
+  )
+
+  await store.setBool(key.qualify(protocol.address), true)
+  await store.setBool(key.qualifyMember(protocol.address), true)
+
+  await protocol.initialize(
+    [helper.zero1,
+      router.address,
+      factory.address, // factory
+      npm.address,
+      helper.randomAddress(),
+      helper.randomAddress()
+    ],
+    [helper.ether(0), // Cover Fee
+      helper.ether(0), // Min Cover Stake
+      helper.ether(250), // Min Reporting Stake
+      7 * DAYS, // Claim period
+      helper.percentage(30), // Governance Burn Rate: 30%
+      helper.percentage(10), // Governance Reporter Commission: 10%
+      helper.percentage(6.5), // Claim: Platform Fee: 6.5%
+      helper.percentage(5), // Claim: Reporter Commission: 5%
+      helper.percentage(0.5), // Flash Loan Fee: 0.5%
+      helper.percentage(2.5), // Flash Loan Protocol Fee: 2.5%
+      1 * DAYS, // cooldown period,
+      1 * DAYS // state and liquidity update interval
+    ]
+  )
+
+  await protocol.grantRoles([{ account: owner.address, roles: [key.ACCESS_CONTROL.UPGRADE_AGENT, key.ACCESS_CONTROL.COVER_MANAGER, key.ACCESS_CONTROL.LIQUIDITY_MANAGER, key.ACCESS_CONTROL.PAUSE_AGENT, key.ACCESS_CONTROL.UNPAUSE_AGENT] }])
+  await protocol.grantRole(key.ACCESS_CONTROL.UPGRADE_AGENT, protocol.address)
+
+  const cover = await deployer.deployWithLibraries(cache, 'Cover',
+    {
+      AccessControlLibV1: accessControlLibV1.address,
+      BaseLibV1: baseLibV1.address,
+      CoverLibV1: coverLibV1.address,
+      ProtoUtilV1: protoUtilV1.address,
+      StoreKeyUtil: storeKeyUtil.address,
+      ValidationLibV1: validationLibV1.address
+    },
+    store.address
+  )
+
+  await protocol.addContract(key.PROTOCOL.CNS.COVER, cover.address)
+  await cover.initialize(dai.address, key.toBytes32('DAI'))
+
+  const stakingContract = await deployer.deployWithLibraries(cache, 'CoverStake', {
+    AccessControlLibV1: accessControlLibV1.address,
+    BaseLibV1: baseLibV1.address,
+    CoverUtilV1: coverUtilV1.address,
+    RoutineInvokerLibV1: routineInvokerLibV1.address,
+    NTransferUtilV2: transferLib.address,
+    ProtoUtilV1: protoUtilV1.address,
+    StoreKeyUtil: storeKeyUtil.address,
+    ValidationLibV1: validationLibV1.address
+  }, store.address)
+
+  await protocol.addContract(key.PROTOCOL.CNS.COVER_STAKE, stakingContract.address)
+
+  const reassuranceContract = await deployer.deployWithLibraries(cache, 'CoverReassurance', {
+    AccessControlLibV1: accessControlLibV1.address,
+    BaseLibV1: baseLibV1.address,
+    CoverUtilV1: coverUtilV1.address,
+    RoutineInvokerLibV1: routineInvokerLibV1.address,
+    NTransferUtilV2: transferLib.address,
+    ProtoUtilV1: protoUtilV1.address,
+    StoreKeyUtil: storeKeyUtil.address,
+    ValidationLibV1: validationLibV1.address
+  }, store.address)
+
+  await protocol.addContract(key.PROTOCOL.CNS.COVER_REASSURANCE, reassuranceContract.address)
+
+  const vaultFactoryLib = await deployer.deployWithLibraries(cache, 'VaultFactoryLibV1', {
+    AccessControlLibV1: accessControlLibV1.address,
+    BaseLibV1: baseLibV1.address,
+    NTransferUtilV2: transferLib.address,
+    ProtoUtilV1: protoUtilV1.address,
+    RegistryLibV1: registryLibV1.address,
+    ValidationLibV1: validationLibV1.address
+  })
+
+  const vaultFactory = await deployer.deployWithLibraries(cache, 'VaultFactory',
+    {
+      AccessControlLibV1: accessControlLibV1.address,
+      BaseLibV1: baseLibV1.address,
+      ProtoUtilV1: protoUtilV1.address,
+      ValidationLibV1: validationLibV1.address,
+      VaultFactoryLibV1: vaultFactoryLib.address
+    }
+    , store.address
+  )
+
+  await protocol.addContract(key.PROTOCOL.CNS.COVER_VAULT_FACTORY, vaultFactory.address)
+  await protocol.grantRole(key.ACCESS_CONTROL.UPGRADE_AGENT, cover.address)
+
+  const vaultLib = await deployer.deployWithLibraries(cache, 'VaultLibV1', {
+    CoverUtilV1: coverUtilV1.address,
+    RoutineInvokerLibV1: routineInvokerLibV1.address,
+    ProtoUtilV1: protoUtilV1.address,
+    RegistryLibV1: registryLibV1.address,
+    StoreKeyUtil: storeKeyUtil.address,
+    StrategyLibV1: strategyLibV1.address
+  })
+
+  const vaultDelegate = await deployer.deployWithLibraries(cache, 'VaultDelegate',
+    {
+      AccessControlLibV1: accessControlLibV1.address,
+      BaseLibV1: baseLibV1.address,
+      ProtoUtilV1: protoUtilV1.address,
+      RoutineInvokerLibV1: routineInvokerLibV1.address,
+      StoreKeyUtil: storeKeyUtil.address,
+      StrategyLibV1: strategyLibV1.address,
+      ValidationLibV1: validationLibV1.address,
+      VaultLibV1: vaultLib.address
+    }
+    , store.address
+  )
+
+  await protocol.addContract(key.PROTOCOL.CNS.COVER_VAULT_DELEGATE, vaultDelegate.address)
+
+  const priceDiscovery = await deployer.deployWithLibraries(cache, 'PriceDiscovery', {
+    AccessControlLibV1: accessControlLibV1.address,
+    BaseLibV1: baseLibV1.address,
+    PriceLibV1: priceLibV1.address,
+    ProtoUtilV1: protoUtilV1.address,
+    ValidationLibV1: validationLibV1.address
+  }, store.address)
+
+  await protocol.addContract(key.PROTOCOL.CNS.PRICE_DISCOVERY, priceDiscovery.address)
+
+  const cxTokenFactoryLib = await deployer.deployWithLibraries(cache, 'cxTokenFactoryLibV1', {
+    AccessControlLibV1: accessControlLibV1.address,
+    BaseLibV1: baseLibV1.address,
+    ValidationLibV1: validationLibV1.address
+  })
+
+  const cxTokenFactory = await deployer.deployWithLibraries(cache, 'cxTokenFactory',
+    {
+      AccessControlLibV1: accessControlLibV1.address,
+      BaseLibV1: baseLibV1.address,
+      cxTokenFactoryLibV1: cxTokenFactoryLib.address,
+      StoreKeyUtil: storeKeyUtil.address,
+      ValidationLibV1: validationLibV1.address
+    }
+    , store.address
+  )
+
+  await protocol.addContract(key.PROTOCOL.CNS.COVER_CXTOKEN_FACTORY, cxTokenFactory.address)
+
+  const governance = await deployer.deployWithLibraries(cache, 'Governance',
+    {
+      AccessControlLibV1: accessControlLibV1.address,
+      BaseLibV1: baseLibV1.address,
+      CoverUtilV1: coverUtilV1.address,
+      GovernanceUtilV1: governanceUtilV1.address,
+      NTransferUtilV2: transferLib.address,
+      ProtoUtilV1: protoUtilV1.address,
+      RegistryLibV1: registryLibV1.address,
+      StoreKeyUtil: storeKeyUtil.address,
+      ValidationLibV1: validationLibV1.address
+    },
+    store.address
+  )
+
+  await protocol.addContract(key.PROTOCOL.CNS.GOVERNANCE, governance.address)
+
+  const resolution = await deployer.deployWithLibraries(cache, 'Resolution',
+    {
+      AccessControlLibV1: accessControlLibV1.address,
+      BaseLibV1: baseLibV1.address,
+      RoutineInvokerLibV1: routineInvokerLibV1.address,
+      StoreKeyUtil: storeKeyUtil.address,
+      ProtoUtilV1: protoUtilV1.address,
+      CoverUtilV1: coverUtilV1.address,
+      NTransferUtilV2: transferLib.address,
+      ValidationLibV1: validationLibV1.address,
+      GovernanceUtilV1: governanceUtilV1.address
+    },
+    store.address
+  )
+
+  await protocol.addContract(key.PROTOCOL.CNS.GOVERNANCE_RESOLUTION, resolution.address)
+
+  const policy = await deployer.deployWithLibraries(cache, 'Policy', {
+    AccessControlLibV1: accessControlLibV1.address,
+    BaseLibV1: baseLibV1.address,
+    CoverUtilV1: coverUtilV1.address,
+    PolicyHelperV1: policyHelperV1.address,
+    StrategyLibV1: strategyLibV1.address,
+    ValidationLibV1: validationLibV1.address
+  }, store.address)
+
+  await protocol.addContract(key.PROTOCOL.CNS.COVER_POLICY, policy.address)
+
+  const liquidityEngine = await deployer.deployWithLibraries(cache, 'LiquidityEngine', {
+    AccessControlLibV1: accessControlLibV1.address,
+    BaseLibV1: baseLibV1.address,
+    StoreKeyUtil: storeKeyUtil.address,
+    StrategyLibV1: strategyLibV1.address,
+    ValidationLibV1: validationLibV1.address
+  }, store.address)
+
+  await protocol.addContract(key.PROTOCOL.CNS.LIQUIDITY_ENGINE, liquidityEngine.address)
+
+  const coverKey = key.toBytes32('foo-bar')
+  const stakeWithFee = helper.ether(10_000)
+  const initialReassuranceAmount = helper.ether(1_000_000)
+  const initialLiquidity = helper.ether(4_000_000)
+  const minReportingStake = helper.ether(250)
+  const reportingPeriod = 7 * DAYS
+  const cooldownPeriod = 1 * DAYS
+  const claimPeriod = 7 * DAYS
+  const floor = helper.percentage(7)
+  const ceiling = helper.percentage(45)
+
+  const requiresWhitelist = false
+  const values = [stakeWithFee, initialReassuranceAmount, minReportingStake, reportingPeriod, cooldownPeriod, claimPeriod, floor, ceiling]
+
+  const info = key.toBytes32('info')
+
+  cover.updateCoverCreatorWhitelist(owner.address, true)
+
+  await npm.approve(stakingContract.address, stakeWithFee)
+  await dai.approve(reassuranceContract.address, initialReassuranceAmount)
+
+  await cover.addCover(coverKey, info, dai.address, requiresWhitelist, values)
+  await cover.deployVault(coverKey)
+
+  const vault = await composer.vault.getVault({
+    store: store,
+    libs: {
+      accessControlLibV1: accessControlLibV1,
+      baseLibV1: baseLibV1,
+      transferLib: transferLib,
+      protoUtilV1: protoUtilV1,
+      registryLibV1: registryLibV1,
+      validationLib: validationLibV1
+    }
+  }, coverKey)
+
+  await dai.approve(vault.address, initialLiquidity)
+  await npm.approve(vault.address, minReportingStake)
+  await vault.addLiquidity(coverKey, initialLiquidity, minReportingStake)
+
+  return {
+    npm,
+    dai,
+    npmDai,
+    store,
+    router,
+    storeKeyUtil,
+    protoUtilV1,
+    accessControlLibV1,
+    registryLibV1,
+    coverUtilV1,
+    governanceUtilV1,
+    validationLibV1,
+    baseLibV1,
+    transferLib,
+    priceLibV1,
+    protocol,
+    routineInvokerLibV1,
+    cover,
+    coverLibV1,
+    policyHelperV1,
+    strategyLibV1,
+    stakingContract,
+    reassuranceContract,
+    governance,
+    resolution,
+    vault,
+    coverKey,
+    liquidityEngine
+  }
+}
+
+module.exports = { deployDependencies }

--- a/util/composer/fakes.js
+++ b/util/composer/fakes.js
@@ -7,7 +7,7 @@ const deployAll = async (cache, tokens) => {
   const pair = await deployer.deploy(cache, 'FakeUniswapV2PairLike', '0x0000000000000000000000000000000000000001', '0x0000000000000000000000000000000000000002')
   const factory = await deployer.deploy(cache, 'FakeUniswapV2FactoryLike', pair.address)
   const lendingPool = await deployer.deploy(cache, 'FakeAaveLendingPool', aToken.address)
-  const daiDelegator = await deployer.deploy(cache, 'FakeCompoundERC20Delegator', dai.address, cDai.address)
+  const daiDelegator = await deployer.deploy(cache, 'FakeCompoundDaiDelegator', dai.address, cDai.address)
 
   await dai.addMinter(lendingPool.address, true)
   await aToken.addMinter(lendingPool.address, true)


### PR DESCRIPTION
- Added a check on strategy withdrawal to ensure that redeeming aTokens or cTokens results in stablecoin withdrawals
- Added `getLendingPeriods` to `ILiquidityEngine`
- Refactored `getLendingPeriodKey` and `getWithdrawalWindowKey` on StrategyLibV1 to drop `ignoreMissingKey` check
- Added more tests to increase coverage