### PR TITLE
Cover Stake Coverage

### DIFF
--- a/contracts/core/delegates/VaultDelegateWithFlashLoan.sol
+++ b/contracts/core/delegates/VaultDelegateWithFlashLoan.sol
@@ -73,13 +73,15 @@ abstract contract VaultDelegateWithFlashLoan is VaultDelegateBase {
 
     stablecoin = IERC20(s.getStablecoin());
 
-    require(address(stablecoin) == token, "Unknown token");
-    require(amount > 0, "Loan too small");
-    require(fee > 0, "Fee too little");
+    // require(address(stablecoin) == token, "Unknown token"); <-- already checked in `getFlashFeesInternal`
+    // require(amount > 0, "Loan too small"); <-- already checked in `getFlashFeesInternal`
 
     s.setBoolByKeys(ProtoUtilV1.NS_COVER_HAS_FLASH_LOAN, coverKey, true);
 
     (fee, protocolFee) = s.getFlashFeesInternal(coverKey, token, amount);
+
+    require(fee > 0, "Loan too small");
+    require(protocolFee > 0, "Loan too small");
   }
 
   function postFlashLoan(

--- a/contracts/core/lifecycle/CoverStake.sol
+++ b/contracts/core/lifecycle/CoverStake.sol
@@ -59,7 +59,7 @@ contract CoverStake is ICoverStake, Recoverable {
     s.npmToken().ensureTransferFrom(account, address(this), amount);
 
     if (fee > 0) {
-      s.npmToken().ensureTransferFrom(address(this), s.getBurnAddress(), fee);
+      s.npmToken().ensureTransfer(s.getBurnAddress(), fee);
       emit FeeBurned(key, fee);
     }
 

--- a/contracts/core/policy/Policy.sol
+++ b/contracts/core/policy/Policy.sol
@@ -64,7 +64,7 @@ contract Policy is IPolicy, Recoverable {
 
     lastPolicyId += 1;
 
-    emit CoverPurchased(key, msg.sender, address(cxToken), fee, amountToCover, cxToken.expiresOn(), referralCode, _lastPolicyId);
+    emit CoverPurchased(key, msg.sender, address(cxToken), fee, amountToCover, cxToken.expiresOn(), referralCode, lastPolicyId);
     return (address(cxToken), lastPolicyId);
   }
 

--- a/contracts/mock/MockFlashBorrower.sol
+++ b/contracts/mock/MockFlashBorrower.sol
@@ -1,0 +1,54 @@
+// Neptune Mutual Protocol (https://neptunemutual.com)
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.0;
+import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
+import "openzeppelin-solidity/contracts/interfaces/IERC3156FlashLender.sol";
+import "hardhat/console.sol";
+
+contract MockFlashBorrower is IERC3156FlashBorrower {
+  IERC20 private _stablecoin;
+  IERC3156FlashLender private _provider;
+  bytes32 private _returnValue = keccak256("ERC3156FlashBorrower.onFlashLoan");
+  bool private _createsApproval = true;
+
+  constructor(IERC20 stablecoin, IERC3156FlashLender provider) {
+    _stablecoin = stablecoin;
+    _provider = provider;
+  }
+
+  function setStablecoin(IERC20 value) external {
+    _stablecoin = value;
+  }
+
+  function setReturnValue(bytes32 value) external {
+    _returnValue = value;
+  }
+
+  function setCreateApproval(bool value) external {
+    _createsApproval = value;
+  }
+
+  function borrow(uint256 amount, bytes memory data) external {
+    uint256 allowance = _stablecoin.allowance(address(this), address(_provider));
+    uint256 fee = _provider.flashFee(address(_stablecoin), amount);
+    uint256 repayment = amount + fee;
+
+    if (_createsApproval) {
+      _stablecoin.approve(address(_provider), allowance + repayment);
+    }
+
+    _provider.flashLoan(this, address(_stablecoin), amount, data);
+  }
+
+  function onFlashLoan(
+    address initiator,
+    address, /*token*/
+    uint256, /*amount*/
+    uint256, /*fee*/
+    bytes calldata /*data*/
+  ) external view override returns (bytes32) {
+    require(msg.sender == address(_provider), "FlashBorrower: Untrusted lender");
+    require(initiator == address(this), "FlashBorrower: Untrusted loan initiator");
+    return _returnValue;
+  }
+}

--- a/test/specs/lifecycle/cover-stake/increase-stake.spec.js
+++ b/test/specs/lifecycle/cover-stake/increase-stake.spec.js
@@ -88,6 +88,22 @@ describe('CoverStake: increaseStake', () => {
     event.args.amount.should.equal(amount)
   })
 
+  it('correctly burns fees', async () => {
+    const [owner, alice] = await ethers.getSigners()
+    const amount = ethers.BigNumber.from('100')
+    const fee = ethers.BigNumber.from('20')
+
+    await deployed.npm.transfer(alice.address, amount)
+    await deployed.npm.approve(deployed.stakingContract.address, amount.add(fee))
+
+    const tx = await deployed.stakingContract.connect(alice).increaseStake(coverKey, owner.address, amount, fee)
+    const { events } = await tx.wait()
+    const event = events.find(x => x.event === 'FeeBurned')
+
+    event.args.key.should.equal(coverKey)
+    event.args.amount.should.equal(fee)
+  })
+
   it('reverts when fee is less than amount', async () => {
     const [owner, alice] = await ethers.getSigners()
     const amount = helper.ether(100)

--- a/test/specs/liquidity/vault/flashloan.spec.js
+++ b/test/specs/liquidity/vault/flashloan.spec.js
@@ -1,7 +1,10 @@
 /* eslint-disable no-unused-expressions */
+const { ethers } = require('hardhat')
 const BigNumber = require('bignumber.js')
-// const { helper } = require('../../../../util')
-// const { deployDependencies } = require('./deps')
+const { deployer, key, helper } = require('../../../../util')
+const { deployDependencies } = require('./deps')
+
+const cache = null
 
 require('chai')
   .use(require('chai-as-promised'))
@@ -9,13 +12,73 @@ require('chai')
   .should()
 
 describe('Flashloan', () => {
-  // let deployed
+  let deployed, borrower
 
-  // before(async () => {
-  //   deployed = await deployDependencies()
-  // })
+  before(async () => {
+    deployed = await deployDependencies()
+    borrower = await deployer.deploy(cache, 'MockFlashBorrower', deployed.dai.address, deployed.vault.address)
+  })
 
-  // it('todo', async () => {
+  it('must successfully lend out a flash loan', async () => {
+    const amount = '8000'
+    const fee = await deployed.vault.flashFee(deployed.dai.address, amount)
 
-  // })
+    // First transfer the fee to the contract
+    await deployed.dai.transfer(borrower.address, fee)
+
+    deployed.vault.on('FlashLoanBorrowed', (_lender, _borrower, _stablecoin, _amount, _fee) => {
+      _lender.should.equal(deployed.vault.address)
+      _borrower.should.equal(borrower.address)
+      _stablecoin.should.equal(deployed.dai.address)
+      _amount.should.equal(amount)
+      _fee.should.equal(fee)
+    })
+
+    await borrower.borrow(amount, 0)
+  })
+
+  it('must revert when a vault has insufficient balance', async () => {
+    const amount = helper.ether(1_000_000_000)
+    await borrower.borrow(amount, 0)
+      .should.be.rejectedWith('Amount insufficient')
+  })
+
+  it('must revert when zero amount is specified', async () => {
+    const amount = '0'
+    await borrower.borrow(amount, 0)
+      .should.be.rejectedWith('Please specify amount')
+  })
+
+  it('must revert when the loan is too small', async () => {
+    await borrower.borrow('1', 0).should.be.rejectedWith('Loan too small')
+    await borrower.borrow('7999', 0).should.be.rejectedWith('Loan too small')
+  })
+
+  it('must revert when an unknown token is being requested', async () => {
+    const amount = helper.ether(1)
+
+    await borrower.setStablecoin(deployed.npm.address)
+
+    await borrower.borrow(amount, 0)
+      .should.be.rejectedWith('Unsupported token')
+
+    // Reset back
+    await borrower.setStablecoin(deployed.dai.address)
+  })
+
+  it('must revert when an invalid value is returned', async () => {
+    const amount = '8000'
+    const fee = await deployed.vault.flashFee(deployed.dai.address, amount)
+
+    // First transfer the fee to the contract
+    await deployed.dai.transfer(borrower.address, fee)
+
+    await borrower.setReturnValue(key.toBytes32('foobar'))
+
+    await borrower.borrow(amount, 0)
+      .should.be.rejectedWith('IERC3156: Callback failed')
+
+    // Reset back
+    await borrower.setReturnValue(ethers.utils.solidityKeccak256(['string'], ['ERC3156FlashBorrower.onFlashLoan']))
+  })
 })


### PR DESCRIPTION
- Refactored `increaseStake` function to use `ensureTransfer` instead of `ensureTransferFrom` when transferring out of the same contract
- Added test case of fee burning