### PR TITLE
Refactor and Todo List

### DIFF
--- a/contracts/core/Protocol.sol
+++ b/contracts/core/Protocol.sol
@@ -38,6 +38,7 @@ contract Protocol is IProtocol, ProtoBase {
    * @param values[9] flashLoanFeeProtocol
    * @param values[10] resolutionCoolDownPeriod
    * @param values[11] state and liquidity update interval
+   * @param values[12] max lending ratio
    */
   function initialize(address[] memory addresses, uint256[] memory values) external override nonReentrant whenNotPaused {
     // @suppress-initialization Can only be initialized by the deployer or an admin
@@ -81,6 +82,7 @@ contract Protocol is IProtocol, ProtoBase {
     s.setUintByKey(ProtoUtilV1.NS_COVER_LIQUIDITY_FLASH_LOAN_FEE_PROTOCOL, values[9]);
     s.setUintByKey(ProtoUtilV1.NS_RESOLUTION_COOL_DOWN_PERIOD, values[10]);
     s.setUintByKey(ProtoUtilV1.NS_LIQUIDITY_STATE_UPDATE_INTERVAL, values[11]);
+    s.setUintByKey(ProtoUtilV1.NS_COVER_LIQUIDITY_MAX_LENDING_RATIO, values[12]);
 
     initialized = 1;
     emit Initialized(addresses, values);

--- a/contracts/core/lifecycle/Cover.sol
+++ b/contracts/core/lifecycle/Cover.sol
@@ -133,7 +133,7 @@ contract Cover is CoverBase {
    */
   function updateCoverCreatorWhitelist(address account, bool status) external override nonReentrant {
     s.mustNotBePaused();
-    AccessControlLibV1.mustBeCoverManager(s);
+    AccessControlLibV1.mustBeGovernanceAgent(s);
 
     s.updateCoverCreatorWhitelistInternal(account, status);
     emit CoverCreatorWhitelistUpdated(account, status);

--- a/contracts/core/lifecycle/CoverStake.sol
+++ b/contracts/core/lifecycle/CoverStake.sol
@@ -82,7 +82,6 @@ contract CoverStake is ICoverStake, Recoverable {
     address account,
     uint256 amount
   ) external override nonReentrant {
-    // @todo this function is not called anywhere. Remove this.
     // @suppress-acl Can only be accessed by the latest cover contract
     s.mustNotBePaused();
     s.mustBeValidCoverKey(key);

--- a/contracts/core/liquidity/LiquidityEngine.sol
+++ b/contracts/core/liquidity/LiquidityEngine.sol
@@ -64,6 +64,20 @@ contract LiquidityEngine is ILiquidityEngine, Recoverable {
     s.setLendingPeriodsInternal(0, lendingPeriod, withdrawalWindow);
   }
 
+  function setMaxLendingRatio(uint256 ratio) external override nonReentrant {
+    require(ratio > 0, "Please specify lending ratio");
+    require(ratio <= ProtoUtilV1.MULTIPLIER, "Invalid lending ratio");
+
+    s.mustNotBePaused();
+    AccessControlLibV1.mustBeLiquidityManager(s);
+
+    s.setMaxLendingRatioInternal(ratio);
+  }
+
+  function getMaxLendingRatio() external view override returns (uint256 ratio) {
+    return s.getMaxLendingRatioInternal();
+  }
+
   function getLendingPeriods(bytes32 coverKey) external view override returns (uint256 lendingPeriod, uint256 withdrawalWindow) {
     return s.getLendingPeriodsInternal(coverKey);
   }

--- a/contracts/core/liquidity/VaultBase.sol
+++ b/contracts/core/liquidity/VaultBase.sol
@@ -12,6 +12,9 @@ abstract contract VaultBase is ERC20, Recoverable, IVault {
   using RegistryLibV1 for IStore;
   using NTransferUtilV2 for IERC20;
 
+  /// @dev POD token contract symbol
+  string private constant _POD_TOKEN_SYMBOL = "nDAI";
+
   bytes32 public override key;
   address public override sc;
 
@@ -19,13 +22,13 @@ abstract contract VaultBase is ERC20, Recoverable, IVault {
     IStore store,
     bytes32 coverKey,
     IERC20 stablecoin
-  ) ERC20(_getTokenName(coverKey), "POD") Recoverable(store) {
+  ) ERC20(_getTokenName(coverKey), _POD_TOKEN_SYMBOL) Recoverable(store) {
     key = coverKey;
     sc = address(stablecoin);
   }
 
   function _getTokenName(bytes32 coverKey) private pure returns (string memory) {
-    return string(abi.encodePacked(string(abi.encodePacked(coverKey)), "-pod"));
+    return string(abi.encodePacked(string(abi.encodePacked(coverKey)), "-ndai"));
   }
 
   function delgate() public view returns (IVaultDelegate) {

--- a/contracts/interfaces/ILiquidityEngine.sol
+++ b/contracts/interfaces/ILiquidityEngine.sol
@@ -8,8 +8,9 @@ pragma solidity 0.8.0;
 interface ILiquidityEngine is IMember {
   event StrategyAdded(address indexed strategy);
   event StrategyDisabled(address indexed strategy);
-  event LendingPeriodSet(uint256 lendingPeriod, uint256 withdrawalWindow);
+  event LendingPeriodSet(bytes32 indexed coverKey, uint256 lendingPeriod, uint256 withdrawalWindow);
   event LiquidityStateUpdateIntervalSet(uint256 duration);
+  event MaxLendingRatioSet(uint256 ratio);
 
   function addStrategies(address[] memory strategies) external;
 
@@ -26,6 +27,10 @@ interface ILiquidityEngine is IMember {
   function getLendingPeriods(bytes32 coverKey) external view returns (uint256 lendingPeriod, uint256 withdrawalWindow);
 
   function setLiquidityStateUpdateInterval(uint256 value) external;
+
+  function setMaxLendingRatio(uint256 ratio) external;
+
+  function getMaxLendingRatio() external view returns (uint256 ratio);
 
   function getDisabledStrategies() external view returns (address[] memory strategies);
 

--- a/contracts/libraries/GovernanceUtilV1.sol
+++ b/contracts/libraries/GovernanceUtilV1.sol
@@ -350,7 +350,7 @@ library GovernanceUtilV1 {
     return fromKey > 0 ? fromKey : fallbackValue;
   }
 
-  function getResolutionDeadlineInternal(IStore s, bytes32 key) public view returns (uint256) {
+  function getResolutionDeadlineInternal(IStore s, bytes32 key) external view returns (uint256) {
     return s.getUintByKeys(ProtoUtilV1.NS_RESOLUTION_DEADLINE, key);
   }
 }

--- a/contracts/libraries/ProtoUtilV1.sol
+++ b/contracts/libraries/ProtoUtilV1.sol
@@ -11,9 +11,6 @@ library ProtoUtilV1 {
 
   uint256 public constant MULTIPLIER = 10_000;
 
-  // @todo Configure this magic number.
-  uint256 public constant MAX_LENDING_RATIO = 500; // 5% (divided by 10,000)
-
   /// @dev Protocol contract namespace
   bytes32 public constant CNS_CORE = "cns:core";
 
@@ -84,6 +81,7 @@ library ProtoUtilV1 {
   bytes32 public constant NS_VAULT_LENDING_INCOMES = "ns:vault:lending:incomes";
   bytes32 public constant NS_VAULT_LENDING_LOSSES = "ns:vault:lending:losses";
   bytes32 public constant NS_COVER_LIQUIDITY_LENDING_PERIOD = "ns:cover:liquidity:len:p";
+  bytes32 public constant NS_COVER_LIQUIDITY_MAX_LENDING_RATIO = "ns:cover:liquidity:max:lr";
   bytes32 public constant NS_COVER_LIQUIDITY_WITHDRAWAL_WINDOW = "ns:cover:liquidity:ww";
   bytes32 public constant NS_COVER_LIQUIDITY_MIN_STAKE = "ns:cover:liquidity:min:stake";
   bytes32 public constant NS_COVER_LIQUIDITY_STAKE = "ns:cover:liquidity:stake";

--- a/contracts/libraries/RoutineInvokerLibV1.sol
+++ b/contracts/libraries/RoutineInvokerLibV1.sol
@@ -174,7 +174,7 @@ library RoutineInvokerLibV1 {
     address vault = s.getVaultAddress(key);
     IERC20 stablecoin = IERC20(s.getStablecoin());
 
-    uint256 maximumAllowed = (stablecoin.balanceOf(vault) * ProtoUtilV1.MAX_LENDING_RATIO) / ProtoUtilV1.MULTIPLIER;
+    uint256 maximumAllowed = (stablecoin.balanceOf(vault) * s.getMaxLendingRatioInternal()) / ProtoUtilV1.MULTIPLIER;
     uint256 allocation = maximumAllowed / totalStrategies;
     uint256 weight = strategy.getWeight();
     uint256 canDeposit = (allocation * weight) / ProtoUtilV1.MULTIPLIER;

--- a/contracts/libraries/StakingPoolLibV1.sol
+++ b/contracts/libraries/StakingPoolLibV1.sol
@@ -280,7 +280,8 @@ library StakingPoolLibV1 {
     // First withdraw your rewards
     (rewardToken, rewards, rewardsPlatformFee) = withdrawRewardsInternal(s, key, msg.sender);
 
-    // @suppress-subtraction, @todo: check if the following subtraction could result in an underflow
+    // @suppress-subtraction The maximum amount that can be withdrawn is the staked balance
+    // and therefore underflow is not possible.
     // Individual state
     s.subtractUintByKeys(StakingPoolCoreLibV1.NS_POOL_STAKING_TOKEN_BALANCE, key, msg.sender, amount);
 

--- a/contracts/libraries/StrategyLibV1.sol
+++ b/contracts/libraries/StrategyLibV1.sol
@@ -17,7 +17,8 @@ library StrategyLibV1 {
   using RegistryLibV1 for IStore;
 
   event StrategyAdded(address indexed strategy);
-  event LendingPeriodSet(uint256 lendingPeriod, uint256 withdrawalWindow);
+  event LendingPeriodSet(bytes32 indexed coverKey, uint256 lendingPeriod, uint256 withdrawalWindow);
+  event MaxLendingRatioSet(uint256 ratio);
 
   function _getIsActiveStrategyKey(address strategyAddress) private pure returns (bytes32) {
     return keccak256(abi.encodePacked(ProtoUtilV1.NS_LENDING_STRATEGY_ACTIVE, strategyAddress));
@@ -56,7 +57,7 @@ library StrategyLibV1 {
     s.setUintByKey(getLendingPeriodKey(coverKey), lendingPeriod);
     s.setUintByKey(getWithdrawalWindowKey(coverKey), withdrawalWindow);
 
-    emit LendingPeriodSet(lendingPeriod, withdrawalWindow);
+    emit LendingPeriodSet(coverKey, lendingPeriod, withdrawalWindow);
   }
 
   function getLendingPeriodKey(bytes32 coverKey) public pure returns (bytes32) {
@@ -65,6 +66,20 @@ library StrategyLibV1 {
     }
 
     return ProtoUtilV1.NS_COVER_LIQUIDITY_LENDING_PERIOD;
+  }
+
+  function getMaxLendingRatioInternal(IStore s) external view returns (uint256) {
+    return s.getUintByKey(getMaxLendingRatioKey());
+  }
+
+  function setMaxLendingRatioInternal(IStore s, uint256 ratio) external {
+    s.setUintByKey(getMaxLendingRatioKey(), ratio);
+
+    emit MaxLendingRatioSet(ratio);
+  }
+
+  function getMaxLendingRatioKey() public pure returns (bytes32) {
+    return ProtoUtilV1.NS_COVER_LIQUIDITY_MAX_LENDING_RATIO;
   }
 
   function getWithdrawalWindowKey(bytes32 coverKey) public pure returns (bytes32) {

--- a/contracts/libraries/ValidationLibV1.sol
+++ b/contracts/libraries/ValidationLibV1.sol
@@ -144,7 +144,6 @@ library ValidationLibV1 {
     address caller,
     bytes32 /*strategyName*/
   ) external view {
-    // @todo
     bool callerIsStrategyContract = s.getBoolByKey(_getIsActiveStrategyKey(caller));
     require(callerIsStrategyContract == true, "Not a strategy contract");
   }

--- a/events.md
+++ b/events.md
@@ -6,7 +6,7 @@
 | IClaimsProcessor.json  | ClaimPeriodSet               | NS_ROLES_COVER_MANAGER            |
 | IClaimsProcessor.json  | Claimed                      | Any                               |
 | ICover.json            | CoverCreated                 | Any (Whitelisted)                 |
-| ICover.json            | CoverCreatorWhitelistUpdated | NS_ROLES_COVER_MANAGER            |
+| ICover.json            | CoverCreatorWhitelistUpdated | NS_ROLES_GOVERNANCE_AGENT         |
 | ICover.json            | CoverFeeSet                  | NS_ROLES_COVER_MANAGER            |
 | ICover.json            | CoverInitialized             | NS_ROLES_COVER_MANAGER            |
 | ICover.json            | CoverStopped                 | NS_ROLES_GOVERNANCE_ADMIN         |

--- a/test/bdd/fractionalization.js
+++ b/test/bdd/fractionalization.js
@@ -53,12 +53,12 @@ describe('Fractionalization of Reserves', () => {
   it('does not allow fractional reserves', async () => {
     let totalPurchased = 0
     const amount = 2_000_000
-    const args = [coverKey, 2, helper.ether(amount)]
+    const args = [coverKey, 2, helper.ether(amount), key.toBytes32('REF-CODE-001')]
 
     let feeIncome = ethers.BigNumber.from(0)
 
     for (let i = 0; i < 2; i++) {
-      const info = (await contracts.policy.getCoverFeeInfo(...args))
+      const info = (await contracts.policy.getCoverFeeInfo(args[0], args[1], args[2]))
       const fee = info.fee
       const available = info.totalAvailableLiquidity
 
@@ -82,8 +82,8 @@ describe('Fractionalization of Reserves', () => {
 
     // Never ending
     for (let i = 0; i < 20; i++) {
-      const args = [coverKey, 2, helper.ether(amount)]
-      const info = (await contracts.policy.getCoverFeeInfo(...args))
+      const args = [coverKey, 2, helper.ether(amount), key.toBytes32('REF-CODE-001')]
+      const info = (await contracts.policy.getCoverFeeInfo(args[0], args[1], args[2]))
       const fee = info.fee
       const available = info.totalAvailableLiquidity
 
@@ -101,8 +101,8 @@ describe('Fractionalization of Reserves', () => {
     const amount = 250_000
 
     for (let i = 0; i < 8; i++) {
-      const args = [coverKey, 1, helper.ether(amount)]
-      const info = (await contracts.policy.getCoverFeeInfo(...args))
+      const args = [coverKey, 1, helper.ether(amount), key.toBytes32('REF-CODE-001')]
+      const info = (await contracts.policy.getCoverFeeInfo(args[0], args[1], args[2]))
       const fee = info.fee
 
       if (i < 4) {

--- a/test/specs/cx-token-factory/deps.js
+++ b/test/specs/cx-token-factory/deps.js
@@ -133,11 +133,12 @@ const deployDependencies = async () => {
       helper.percentage(0.5), // Flash Loan Fee: 0.5%
       helper.percentage(2.5), // Flash Loan Protocol Fee: 2.5%
       1 * DAYS, // cooldown period,
-      1 * DAYS // state and liquidity update interval
+      1 * DAYS, // state and liquidity update interval
+      helper.percentage(5) // maximum lending ratio
     ]
   )
 
-  await protocol.grantRoles([{ account: owner.address, roles: [key.ACCESS_CONTROL.UPGRADE_AGENT, key.ACCESS_CONTROL.COVER_MANAGER, key.ACCESS_CONTROL.LIQUIDITY_MANAGER, key.ACCESS_CONTROL.PAUSE_AGENT, key.ACCESS_CONTROL.UNPAUSE_AGENT] }])
+  await protocol.grantRoles([{ account: owner.address, roles: [key.ACCESS_CONTROL.UPGRADE_AGENT, key.ACCESS_CONTROL.COVER_MANAGER, key.ACCESS_CONTROL.GOVERNANCE_AGENT, key.ACCESS_CONTROL.LIQUIDITY_MANAGER, key.ACCESS_CONTROL.PAUSE_AGENT, key.ACCESS_CONTROL.UNPAUSE_AGENT] }])
   await protocol.grantRole(key.ACCESS_CONTROL.UPGRADE_AGENT, protocol.address)
 
   const cover = await deployer.deployWithLibraries(cache, 'Cover',

--- a/test/specs/discovery/deps.js
+++ b/test/specs/discovery/deps.js
@@ -133,7 +133,8 @@ const deployDependencies = async () => {
       helper.percentage(0.5), // Flash Loan Fee: 0.5%
       helper.percentage(2.5), // Flash Loan Protocol Fee: 2.5%
       1 * DAYS, // cooldown period,
-      1 * DAYS // state and liquidity update interval
+      1 * DAYS, // state and liquidity update interval
+      helper.percentage(5) // maximum lending ratio
     ]
   )
 

--- a/test/specs/governance/deps.js
+++ b/test/specs/governance/deps.js
@@ -146,7 +146,8 @@ const deployDependencies = async () => {
       helper.percentage(0.5), // Flash Loan Fee: 0.5%
       helper.percentage(2.5), // Flash Loan Protocol Fee: 2.5%
       1 * DAYS, // cooldown period,
-      1 * DAYS // state and liquidity update interval
+      1 * DAYS, // state and liquidity update interval
+      helper.percentage(5) // maximum lending ratio
     ]
   )
 

--- a/test/specs/governance/resolution/deps.js
+++ b/test/specs/governance/resolution/deps.js
@@ -134,7 +134,8 @@ const deployDependencies = async () => {
       helper.percentage(0.5), // Flash Loan Fee: 0.5%
       helper.percentage(2.5), // Flash Loan Protocol Fee: 2.5%
       1 * DAYS, // cooldown period,
-      1 * DAYS // state and liquidity update interval
+      1 * DAYS, // state and liquidity update interval
+      helper.percentage(5) // maximum lending ratio
     ]
   )
 

--- a/test/specs/lifecycle/cover-provision/deps.js
+++ b/test/specs/lifecycle/cover-provision/deps.js
@@ -134,7 +134,8 @@ const deployDependencies = async () => {
       helper.percentage(0.5), // Flash Loan Fee: 0.5%
       helper.percentage(2.5), // Flash Loan Protocol Fee: 2.5%
       1 * DAYS, // cooldown period,
-      1 * DAYS // state and liquidity update interval
+      1 * DAYS, // state and liquidity update interval
+      helper.percentage(5) // maximum lending ratio
     ]
   )
 
@@ -147,6 +148,7 @@ const deployDependencies = async () => {
         key.ACCESS_CONTROL.LIQUIDITY_MANAGER,
         key.ACCESS_CONTROL.PAUSE_AGENT,
         key.ACCESS_CONTROL.GOVERNANCE_ADMIN,
+        key.ACCESS_CONTROL.GOVERNANCE_AGENT,
         key.ACCESS_CONTROL.UNPAUSE_AGENT
       ]
     }

--- a/test/specs/lifecycle/cover-reassurance/deps.js
+++ b/test/specs/lifecycle/cover-reassurance/deps.js
@@ -134,7 +134,8 @@ const deployDependencies = async () => {
       helper.percentage(0.5), // Flash Loan Fee: 0.5%
       helper.percentage(2.5), // Flash Loan Protocol Fee: 2.5%
       1 * DAYS, // cooldown period,
-      1 * DAYS // state and liquidity update interval
+      1 * DAYS, // state and liquidity update interval
+      helper.percentage(5) // maximum lending ratio
     ]
   )
 
@@ -147,6 +148,7 @@ const deployDependencies = async () => {
         key.ACCESS_CONTROL.LIQUIDITY_MANAGER,
         key.ACCESS_CONTROL.PAUSE_AGENT,
         key.ACCESS_CONTROL.GOVERNANCE_ADMIN,
+        key.ACCESS_CONTROL.GOVERNANCE_AGENT,
         key.ACCESS_CONTROL.UNPAUSE_AGENT
       ]
     }

--- a/test/specs/lifecycle/cover-stake/deps.js
+++ b/test/specs/lifecycle/cover-stake/deps.js
@@ -134,7 +134,8 @@ const deployDependencies = async () => {
       helper.percentage(0.5), // Flash Loan Fee: 0.5%
       helper.percentage(2.5), // Flash Loan Protocol Fee: 2.5%
       1 * DAYS, // cooldown period,
-      1 * DAYS // state and liquidity update interval
+      1 * DAYS, // state and liquidity update interval
+      helper.percentage(5) // maximum lending ratio
     ]
   )
 
@@ -147,6 +148,7 @@ const deployDependencies = async () => {
         key.ACCESS_CONTROL.LIQUIDITY_MANAGER,
         key.ACCESS_CONTROL.PAUSE_AGENT,
         key.ACCESS_CONTROL.GOVERNANCE_ADMIN,
+        key.ACCESS_CONTROL.GOVERNANCE_AGENT,
         key.ACCESS_CONTROL.UNPAUSE_AGENT
       ]
     }

--- a/test/specs/lifecycle/cover/deps.js
+++ b/test/specs/lifecycle/cover/deps.js
@@ -134,7 +134,8 @@ const deployDependencies = async () => {
       helper.percentage(0.5), // Flash Loan Fee: 0.5%
       helper.percentage(2.5), // Flash Loan Protocol Fee: 2.5%
       1 * DAYS, // cooldown period,
-      1 * DAYS // state and liquidity update interval
+      1 * DAYS, // state and liquidity update interval
+      helper.percentage(5) // maximum lending ratio
     ]
   )
 
@@ -147,6 +148,7 @@ const deployDependencies = async () => {
         key.ACCESS_CONTROL.LIQUIDITY_MANAGER,
         key.ACCESS_CONTROL.PAUSE_AGENT,
         key.ACCESS_CONTROL.GOVERNANCE_ADMIN,
+        key.ACCESS_CONTROL.GOVERNANCE_AGENT,
         key.ACCESS_CONTROL.UNPAUSE_AGENT
       ]
     }

--- a/test/specs/lifecycle/cover/initialize.spec.js
+++ b/test/specs/lifecycle/cover/initialize.spec.js
@@ -54,7 +54,8 @@ describe('Cover: initialize', () => {
         helper.percentage(0.5), // Flash Loan Fee: 0.5%
         helper.percentage(2.5), // Flash Loan Protocol Fee: 2.5%
         1 * DAYS, // cooldown period,
-        1 * DAYS // state and liquidity update interval
+        1 * DAYS, // state and liquidity update interval
+        helper.percentage(5)
       ]
     )
 

--- a/test/specs/liquidity/delegates/deps.js
+++ b/test/specs/liquidity/delegates/deps.js
@@ -150,7 +150,8 @@ const deployDependencies = async () => {
       helper.percentage(0.5), // Flash Loan Fee: 0.5%
       helper.percentage(2.5), // Flash Loan Protocol Fee: 2.5%
       1 * DAYS, // cooldown period,
-      1 * DAYS // state and liquidity update interval
+      1 * DAYS, // state and liquidity update interval
+      helper.percentage(5) // maximum lending ratio
     ]
   )
 

--- a/test/specs/liquidity/engine/deps.js
+++ b/test/specs/liquidity/engine/deps.js
@@ -119,7 +119,8 @@ const deployDependencies = async () => {
       helper.percentage(0.5), // Flash Loan Fee: 0.5%
       helper.percentage(2.5), // Flash Loan Protocol Fee: 2.5%
       1 * DAYS, // cooldown period,
-      1 * DAYS // state and liquidity update interval
+      1 * DAYS, // state and liquidity update interval
+      helper.percentage(5) // maximum lending ratio
     ]
   )
 

--- a/test/specs/liquidity/engine/set-max-lending-ratio.spec.js
+++ b/test/specs/liquidity/engine/set-max-lending-ratio.spec.js
@@ -1,0 +1,85 @@
+/* eslint-disable no-unused-expressions */
+const BigNumber = require('bignumber.js')
+const { deployer, key, helper } = require('../../../../util')
+const { deployDependencies } = require('./deps')
+const cache = null
+
+require('chai')
+  .use(require('chai-as-promised'))
+  .use(require('chai-bignumber')(BigNumber))
+  .should()
+
+describe('Liquidity Engine: `setMaxLendingRatio` function', () => {
+  let store,
+    liquidityEngine,
+    accessControlLibV1,
+    baseLibV1,
+    validationLibV1,
+    storeKeyUtil,
+    strategyLibV1,
+    deployed
+
+  before(async () => {
+    deployed = await deployDependencies()
+
+    store = deployed.store
+    accessControlLibV1 = deployed.accessControlLibV1
+    baseLibV1 = deployed.baseLibV1
+    validationLibV1 = deployed.validationLibV1
+    storeKeyUtil = deployed.storeKeyUtil
+    strategyLibV1 = deployed.strategyLibV1
+
+    liquidityEngine = await deployer.deployWithLibraries(cache, 'LiquidityEngine', {
+      AccessControlLibV1: accessControlLibV1.address,
+      BaseLibV1: baseLibV1.address,
+      StoreKeyUtil: storeKeyUtil.address,
+      StrategyLibV1: strategyLibV1.address,
+      ValidationLibV1: validationLibV1.address
+    }, store.address)
+
+    await deployed.protocol.addContract(key.PROTOCOL.CNS.LIQUIDITY_ENGINE, liquidityEngine.address)
+  })
+
+  it('correctly sets lending period', async () => {
+    const ratio = helper.percentage(5)
+
+    const tx = await liquidityEngine.setMaxLendingRatio(ratio)
+
+    const { events } = await tx.wait()
+    const event = events.find(x => x.event === 'MaxLendingRatioSet')
+
+    event.args.ratio.should.equal(ratio)
+
+    const result = await liquidityEngine.getMaxLendingRatio()
+    result.should.equal(ratio)
+  })
+
+  it('reverts when zero is set as the max lending ratio', async () => {
+    const ratio = helper.percentage(0)
+
+    await liquidityEngine.setMaxLendingRatio(ratio)
+      .should.be.rejectedWith('Please specify lending ratio')
+  })
+
+  it('reverts when more than 100% is specified as the max lending ratio', async () => {
+    const ratio = helper.percentage(100.1)
+
+    await liquidityEngine.setMaxLendingRatio(ratio)
+      .should.be.rejectedWith('Invalid lending ratio')
+  })
+
+  it('reverts when protocol is paused', async () => {
+    const ratio = helper.percentage(5)
+
+    await deployed.protocol.pause()
+    await liquidityEngine.setMaxLendingRatio(ratio).should.be.rejectedWith('Protocol is paused')
+    await deployed.protocol.unpause()
+  })
+
+  it('reverts when not accessed by LiquidityManager', async () => {
+    const [, bob] = await ethers.getSigners()
+    const ratio = helper.percentage(5)
+
+    await liquidityEngine.connect(bob).setMaxLendingRatio(ratio).should.be.rejectedWith('Forbidden')
+  })
+})

--- a/test/specs/liquidity/strategy/deps.js
+++ b/test/specs/liquidity/strategy/deps.js
@@ -134,11 +134,12 @@ const deployDependencies = async () => {
       helper.percentage(0.5), // Flash Loan Fee: 0.5%
       helper.percentage(2.5), // Flash Loan Protocol Fee: 2.5%
       1 * DAYS, // cooldown period,
-      1 * DAYS // state and liquidity update interval
+      1 * DAYS, // state and liquidity update interval
+      helper.percentage(5) // maximum lending ratio
     ]
   )
 
-  await protocol.grantRoles([{ account: owner.address, roles: [key.ACCESS_CONTROL.UPGRADE_AGENT, key.ACCESS_CONTROL.COVER_MANAGER, key.ACCESS_CONTROL.LIQUIDITY_MANAGER, key.ACCESS_CONTROL.PAUSE_AGENT, key.ACCESS_CONTROL.UNPAUSE_AGENT] }])
+  await protocol.grantRoles([{ account: owner.address, roles: [key.ACCESS_CONTROL.UPGRADE_AGENT, key.ACCESS_CONTROL.COVER_MANAGER, key.ACCESS_CONTROL.GOVERNANCE_AGENT, key.ACCESS_CONTROL.LIQUIDITY_MANAGER, key.ACCESS_CONTROL.PAUSE_AGENT, key.ACCESS_CONTROL.UNPAUSE_AGENT] }])
   await protocol.grantRole(key.ACCESS_CONTROL.UPGRADE_AGENT, protocol.address)
 
   const cover = await deployer.deployWithLibraries(cache, 'Cover',

--- a/test/specs/liquidity/vault-factory/deps.js
+++ b/test/specs/liquidity/vault-factory/deps.js
@@ -128,7 +128,8 @@ const deployDependencies = async () => {
       helper.percentage(0.5), // Flash Loan Fee: 0.5%
       helper.percentage(2.5), // Flash Loan Protocol Fee: 2.5%
       1 * DAYS, // cooldown period,
-      1 * DAYS // state and liquidity update interval
+      1 * DAYS, // state and liquidity update interval
+      helper.percentage(5) // maximum lending ratio
     ]
   )
 

--- a/test/specs/liquidity/vault/deps.js
+++ b/test/specs/liquidity/vault/deps.js
@@ -134,11 +134,12 @@ const deployDependencies = async () => {
       helper.percentage(0.5), // Flash Loan Fee: 0.5%
       helper.percentage(2.5), // Flash Loan Protocol Fee: 2.5%
       1 * DAYS, // cooldown period,
-      1 * DAYS // state and liquidity update interval
+      1 * DAYS, // state and liquidity update interval
+      helper.percentage(5) // maximum lending ratio
     ]
   )
 
-  await protocol.grantRoles([{ account: owner.address, roles: [key.ACCESS_CONTROL.UPGRADE_AGENT, key.ACCESS_CONTROL.COVER_MANAGER, key.ACCESS_CONTROL.LIQUIDITY_MANAGER, key.ACCESS_CONTROL.PAUSE_AGENT, key.ACCESS_CONTROL.UNPAUSE_AGENT] }])
+  await protocol.grantRoles([{ account: owner.address, roles: [key.ACCESS_CONTROL.UPGRADE_AGENT, key.ACCESS_CONTROL.COVER_MANAGER, key.ACCESS_CONTROL.LIQUIDITY_MANAGER, key.ACCESS_CONTROL.GOVERNANCE_AGENT, key.ACCESS_CONTROL.PAUSE_AGENT, key.ACCESS_CONTROL.UNPAUSE_AGENT] }])
   await protocol.grantRole(key.ACCESS_CONTROL.UPGRADE_AGENT, protocol.address)
 
   const cover = await deployer.deployWithLibraries(cache, 'Cover',

--- a/test/specs/policy-admin/deps.js
+++ b/test/specs/policy-admin/deps.js
@@ -142,11 +142,12 @@ const deployDependencies = async () => {
       helper.percentage(0.5), // Flash Loan Fee: 0.5%
       helper.percentage(2.5), // Flash Loan Protocol Fee: 2.5%
       1 * DAYS, // cooldown period,
-      1 * DAYS // state and liquidity update interval
+      1 * DAYS, // state and liquidity update interval
+      helper.percentage(5) // maximum lending ratio
     ]
   )
 
-  await protocol.grantRoles([{ account: owner.address, roles: [key.ACCESS_CONTROL.UPGRADE_AGENT, key.ACCESS_CONTROL.COVER_MANAGER, key.ACCESS_CONTROL.LIQUIDITY_MANAGER, key.ACCESS_CONTROL.PAUSE_AGENT, key.ACCESS_CONTROL.UNPAUSE_AGENT] }])
+  await protocol.grantRoles([{ account: owner.address, roles: [key.ACCESS_CONTROL.UPGRADE_AGENT, key.ACCESS_CONTROL.COVER_MANAGER, key.ACCESS_CONTROL.LIQUIDITY_MANAGER, key.ACCESS_CONTROL.GOVERNANCE_AGENT, key.ACCESS_CONTROL.PAUSE_AGENT, key.ACCESS_CONTROL.UNPAUSE_AGENT] }])
   await protocol.grantRole(key.ACCESS_CONTROL.UPGRADE_AGENT, protocol.address)
 
   const cover = await deployer.deployWithLibraries(cache, 'Cover',

--- a/test/specs/policy/deps.js
+++ b/test/specs/policy/deps.js
@@ -134,11 +134,12 @@ const deployDependencies = async () => {
       helper.percentage(0.5), // Flash Loan Fee: 0.5%
       helper.percentage(2.5), // Flash Loan Protocol Fee: 2.5%
       1 * DAYS, // cooldown period,
-      1 * DAYS // state and liquidity update interval
+      1 * DAYS, // state and liquidity update interval
+      helper.percentage(5) // maximum lending ratio
     ]
   )
 
-  await protocol.grantRoles([{ account: owner.address, roles: [key.ACCESS_CONTROL.UPGRADE_AGENT, key.ACCESS_CONTROL.COVER_MANAGER, key.ACCESS_CONTROL.LIQUIDITY_MANAGER, key.ACCESS_CONTROL.PAUSE_AGENT, key.ACCESS_CONTROL.UNPAUSE_AGENT] }])
+  await protocol.grantRoles([{ account: owner.address, roles: [key.ACCESS_CONTROL.UPGRADE_AGENT, key.ACCESS_CONTROL.COVER_MANAGER, key.ACCESS_CONTROL.GOVERNANCE_AGENT, key.ACCESS_CONTROL.LIQUIDITY_MANAGER, key.ACCESS_CONTROL.PAUSE_AGENT, key.ACCESS_CONTROL.UNPAUSE_AGENT] }])
   await protocol.grantRole(key.ACCESS_CONTROL.UPGRADE_AGENT, protocol.address)
 
   const cover = await deployer.deployWithLibraries(cache, 'Cover',

--- a/test/specs/pool/bond/deps.js
+++ b/test/specs/pool/bond/deps.js
@@ -133,7 +133,8 @@ const deployDependencies = async () => {
       helper.percentage(0.5), // Flash Loan Fee: 0.5%
       helper.percentage(2.5), // Flash Loan Protocol Fee: 2.5%
       1 * DAYS, // cooldown period,
-      1 * DAYS // state and liquidity update interval
+      1 * DAYS, // state and liquidity update interval
+      helper.percentage(5) // maximum lending ratio
     ]
   )
 

--- a/test/specs/pool/staking/deps.js
+++ b/test/specs/pool/staking/deps.js
@@ -123,7 +123,8 @@ const deployDependencies = async () => {
       helper.percentage(0.5), // Flash Loan Fee: 0.5%
       helper.percentage(2.5), // Flash Loan Protocol Fee: 2.5%
       1 * DAYS, // cooldown period,
-      1 * DAYS // state and liquidity update interval
+      1 * DAYS, // state and liquidity update interval
+      helper.percentage(5) // maximum lending ratio
     ]
   )
 

--- a/test/specs/protocol/add-contract.spec.js
+++ b/test/specs/protocol/add-contract.spec.js
@@ -60,7 +60,8 @@ describe('Adding a New Protocol Contract', () => {
         helper.ether(0.0005), // Flash Loan Fee: 0.5%
         helper.ether(0.0025), // Flash Loan Protocol Fee: 2.5%
         1 * DAYS, // cooldown period,
-        1 * DAYS // state and liquidity update interval
+        1 * DAYS, // state and liquidity update interval
+        helper.percentage(5)
       ]
     )
   })

--- a/test/specs/protocol/add-member.spec.js
+++ b/test/specs/protocol/add-member.spec.js
@@ -60,7 +60,8 @@ describe('Adding a New Protocol Member', () => {
         helper.ether(0.0005), // Flash Loan Fee: 0.5%
         helper.ether(0.0025), // Flash Loan Protocol Fee: 2.5%
         1 * DAYS, // cooldown period,
-        1 * DAYS // state and liquidity update interval
+        1 * DAYS, // state and liquidity update interval
+        helper.percentage(5)
       ]
     )
   })

--- a/test/specs/protocol/ctor-vfns.spec.js
+++ b/test/specs/protocol/ctor-vfns.spec.js
@@ -10,7 +10,7 @@ require('chai')
   .use(require('chai-bignumber')(BigNumber))
   .should()
 
-describe('Constructor & Initializer', () => {
+describe('Protocol Constructor & Initializer', () => {
   const treasury = helper.randomAddress()
   const reassuranceVault = helper.randomAddress()
   let npm, store, router, storeKeyUtil, protoUtilV1, accessControlLibV1, validationLibV1, baseLibV1, registryLibV1
@@ -63,7 +63,8 @@ describe('Constructor & Initializer', () => {
         helper.percentage(0.5), // Flash Loan Fee: 0.5%
         helper.percentage(2.5), // Flash Loan Protocol Fee: 2.5%
         1 * DAYS, // cooldown period,
-        1 * DAYS // state and liquidity update interval
+        1 * DAYS, // state and liquidity update interval
+        helper.percentage(5)
       ]
     )
 
@@ -108,7 +109,8 @@ describe('Constructor & Initializer', () => {
         helper.ether(0.0005), // Flash Loan Fee: 0.5%
         helper.ether(0.0025), // Flash Loan Protocol Fee: 2.5%
         1 * DAYS, // cooldown period,
-        1 * DAYS // state and liquidity update interval
+        1 * DAYS, // state and liquidity update interval
+        helper.percentage(5)
       ]
     )
 
@@ -166,7 +168,8 @@ describe('Constructor & Initializer', () => {
         helper.ether(0.0005), // Flash Loan Fee: 0.5%
         helper.ether(0.0025), // Flash Loan Protocol Fee: 2.5%
         1 * DAYS, // cooldown period,
-        1 * DAYS // state and liquidity update interval
+        1 * DAYS, // state and liquidity update interval
+        helper.percentage(5)
       ]
     )
 
@@ -189,7 +192,8 @@ describe('Constructor & Initializer', () => {
         helper.ether(0.0005), // Flash Loan Fee: 0.5%
         helper.ether(0.0025), // Flash Loan Protocol Fee: 2.5%
         1 * DAYS, // cooldown period,
-        1 * DAYS // state and liquidity update interval
+        1 * DAYS, // state and liquidity update interval
+        helper.percentage(5)
       ]
     )
   })
@@ -242,7 +246,8 @@ describe('Constructor & Initializer', () => {
         helper.ether(0.0005), // Flash Loan Fee: 0.5%
         helper.ether(0.0025), // Flash Loan Protocol Fee: 2.5%
         1 * DAYS, // cooldown period,
-        1 * DAYS // state and liquidity update interval
+        1 * DAYS, // state and liquidity update interval
+        helper.percentage(5)
       ]
     ).should.be.rejectedWith('Invalid NPM')
   })
@@ -281,7 +286,8 @@ describe('Constructor & Initializer', () => {
         helper.ether(0.0005), // Flash Loan Fee: 0.5%
         helper.ether(0.0025), // Flash Loan Protocol Fee: 2.5%
         1 * DAYS, // cooldown period,
-        1 * DAYS // state and liquidity update interval
+        1 * DAYS, // state and liquidity update interval
+        helper.percentage(5)
       ]
     ).should.be.rejectedWith('Invalid Treasury')
   })
@@ -320,7 +326,8 @@ describe('Constructor & Initializer', () => {
         helper.ether(0.0005), // Flash Loan Fee: 0.5%
         helper.ether(0.0025), // Flash Loan Protocol Fee: 2.5%
         1 * DAYS, // cooldown period,
-        1 * DAYS // state and liquidity update interval
+        1 * DAYS, // state and liquidity update interval
+        helper.percentage(5)
       ]
     ).should.be.rejectedWith('Invalid Reassurance Vault')
   })
@@ -362,7 +369,8 @@ describe('Constructor & Initializer', () => {
         helper.ether(0.0005), // Flash Loan Fee: 0.5%
         helper.ether(0.0025), // Flash Loan Protocol Fee: 2.5%
         1 * DAYS, // cooldown period,
-        1 * DAYS // state and liquidity update interval
+        1 * DAYS, // state and liquidity update interval
+        helper.percentage(5)
       ]
     )
 
@@ -387,7 +395,8 @@ describe('Constructor & Initializer', () => {
         helper.ether(0.0005), // Flash Loan Fee: 0.5%
         helper.ether(0.0025), // Flash Loan Protocol Fee: 2.5%
         1 * DAYS, // cooldown period,
-        1 * DAYS // state and liquidity update interval
+        1 * DAYS, // state and liquidity update interval
+        helper.percentage(5)
       ]
     ).should.be.rejectedWith('Forbidden')
   })
@@ -427,7 +436,8 @@ describe('Constructor & Initializer', () => {
         helper.ether(0.0005), // Flash Loan Fee: 0.5%
         helper.ether(0.0025), // Flash Loan Protocol Fee: 2.5%
         1 * DAYS, // cooldown period,
-        1 * DAYS // state and liquidity update interval
+        1 * DAYS, // state and liquidity update interval
+        helper.percentage(5)
       ]
     )
 
@@ -450,7 +460,8 @@ describe('Constructor & Initializer', () => {
         helper.ether(0.0005), // Flash Loan Fee: 0.5%
         helper.ether(0.0025), // Flash Loan Protocol Fee: 2.5%
         1 * DAYS, // cooldown period,
-        1 * DAYS // state and liquidity update interval
+        1 * DAYS, // state and liquidity update interval
+        helper.percentage(5)
       ]
     ).should.be.rejectedWith('Can\'t change NPM')
   })
@@ -489,7 +500,8 @@ describe('Constructor & Initializer', () => {
         helper.ether(0.0005), // Flash Loan Fee: 0.5%
         helper.ether(0.0025), // Flash Loan Protocol Fee: 2.5%
         1 * DAYS, // cooldown period,
-        1 * DAYS // state and liquidity update interval
+        1 * DAYS, // state and liquidity update interval
+        helper.percentage(5)
       ]
     ).should.be.rejectedWith('Invalid Burner')
   })
@@ -529,7 +541,8 @@ describe('Constructor & Initializer', () => {
         helper.ether(0.0005), // Flash Loan Fee: 0.5%
         helper.ether(0.0025), // Flash Loan Protocol Fee: 2.5%
         1 * DAYS, // cooldown period,
-        1 * DAYS // state and liquidity update interval
+        1 * DAYS, // state and liquidity update interval
+        helper.percentage(5)
       ]
     ).should.be.rejectedWith('Invalid Uniswap V2 Router')
   })
@@ -569,7 +582,8 @@ describe('Constructor & Initializer', () => {
         helper.ether(0.0005), // Flash Loan Fee: 0.5%
         helper.ether(0.0025), // Flash Loan Protocol Fee: 2.5%
         1 * DAYS, // cooldown period,
-        1 * DAYS // state and liquidity update interval
+        1 * DAYS, // state and liquidity update interval
+        helper.percentage(5)
       ]
     ).should.be.rejectedWith('Invalid Uniswap V2 Factory')
   })

--- a/test/specs/protocol/pause.spec.js
+++ b/test/specs/protocol/pause.spec.js
@@ -60,7 +60,8 @@ describe('Pausing Protocol', () => {
         helper.ether(0.0005), // Flash Loan Fee: 0.5%
         helper.ether(0.0025), // Flash Loan Protocol Fee: 2.5%
         1 * DAYS, // cooldown period,
-        1 * DAYS // state and liquidity update interval
+        1 * DAYS, // state and liquidity update interval
+        helper.percentage(5)
       ]
     )
   })

--- a/test/specs/protocol/remove-member.spec.js
+++ b/test/specs/protocol/remove-member.spec.js
@@ -60,8 +60,8 @@ describe('Removing Protocol Member(s)', () => {
         helper.ether(0.0005), // Flash Loan Fee: 0.5%
         helper.ether(0.0025), // Flash Loan Protocol Fee: 2.5%
         1 * DAYS, // cooldown period,
-        1 * DAYS // state and liquidity update interval
-      ]
+        1 * DAYS, // state and liquidity update interval
+        helper.percentage(5)]
     )
   })
 

--- a/test/specs/protocol/setup-role.spec.js
+++ b/test/specs/protocol/setup-role.spec.js
@@ -60,7 +60,8 @@ describe('Setup roles in protocol', () => {
         helper.ether(0.0005), // Flash Loan Fee: 0.5%
         helper.ether(0.0025), // Flash Loan Protocol Fee: 2.5%
         1 * DAYS, // cooldown period,
-        1 * DAYS // state and liquidity update interval
+        1 * DAYS, // state and liquidity update interval
+        helper.percentage(5)
       ]
     )
   })

--- a/test/specs/protocol/unpause.spec.js
+++ b/test/specs/protocol/unpause.spec.js
@@ -60,7 +60,8 @@ describe('Unpausing Protocol', () => {
         helper.ether(0.0005), // Flash Loan Fee: 0.5%
         helper.ether(0.0025), // Flash Loan Protocol Fee: 2.5%
         1 * DAYS, // cooldown period,
-        1 * DAYS // state and liquidity update interval
+        1 * DAYS, // state and liquidity update interval
+        helper.percentage(5)
       ]
     )
   })

--- a/test/specs/protocol/upgrade-contract.spec.js
+++ b/test/specs/protocol/upgrade-contract.spec.js
@@ -60,7 +60,8 @@ describe('Upgrading Protocol Contract(s)', () => {
         helper.ether(0.0005), // Flash Loan Fee: 0.5%
         helper.ether(0.0025), // Flash Loan Protocol Fee: 2.5%
         1 * DAYS, // cooldown period,
-        1 * DAYS // state and liquidity update interval
+        1 * DAYS, // state and liquidity update interval
+        helper.percentage(5)
       ]
     )
   })

--- a/test/specs/recoverable/deps.js
+++ b/test/specs/recoverable/deps.js
@@ -119,7 +119,8 @@ const deployDependencies = async () => {
       helper.percentage(0.5), // Flash Loan Fee: 0.5%
       helper.percentage(2.5), // Flash Loan Protocol Fee: 2.5%
       1 * DAYS, // cooldown period,
-      1 * DAYS // state and liquidity update interval
+      1 * DAYS, // state and liquidity update interval
+      helper.percentage(5) // maximum lending ratio
     ]
   )
 

--- a/util/composer/initializer.js
+++ b/util/composer/initializer.js
@@ -71,7 +71,8 @@ const initialize = async (suite, deploymentId) => {
       helper.percentage(0.5), // Flash Loan Fee: 0.5%
       helper.percentage(2.5), // Flash Loan Protocol Fee: 2.5%
       cooldownPeriod,
-      stateUpdateInterval
+      stateUpdateInterval,
+      helper.percentage(5)
     ]
   )
 
@@ -361,7 +362,7 @@ const initialize = async (suite, deploymentId) => {
   },
   {
     account: owner.address,
-    roles: [key.ACCESS_CONTROL.COVER_MANAGER]
+    roles: [key.ACCESS_CONTROL.COVER_MANAGER, key.ACCESS_CONTROL.GOVERNANCE_AGENT]
   }]
 
   await intermediate(cache, protocol, 'grantRoles', payload)


### PR DESCRIPTION
- Dropped the magic number `MAX_LENDING_RATIO` to configure it as a protocol initialization argument
- Refactored `updateCoverCreatorWhitelist` to allow access to governance agent instead of cover manager
- Removed obsolete todo notes for `decreaseStake`
- Added `setMaxLendingRatio` and `getMaxLendingRatio` to LiquidityEngine contract StrategyLibV1 library
- Added code coverage for `setMaxLendingRatio` and `getMaxLendingRatio`
- Updated POD token symbol to `nDAI` to signify POD fungibility
- Checked the subtraction usage on `withdrawInternal` and dropped the todo note
- Dropped obsolete todo note on `ValidationLibV1.callerMustBeSpecificStrategyContract`
- Refactored tests