### PR TITLE
POD Fungibility Refactor

### DIFF
--- a/contracts/core/delegates/VaultDelegateBase.sol
+++ b/contracts/core/delegates/VaultDelegateBase.sol
@@ -13,7 +13,7 @@ import "../../libraries/StrategyLibV1.sol";
 
 /**
  * @title Vault POD (Proof of Deposit)
- * @dev The VaultPod has `_mintPods` and `_redeemPods` features which enables
+ * @dev The VaultPod has `_mintPods` and `_redeemPodCalculation` features which enables
  * POD minting and burning on demand. <br /> <br />
  *
  * **How Does This Work?**

--- a/contracts/libraries/CoverUtilV1.sol
+++ b/contracts/libraries/CoverUtilV1.sol
@@ -145,10 +145,6 @@ library CoverUtilV1 {
     return keccak256(abi.encodePacked(ProtoUtilV1.NS_COVER_STATUS, key, incidentDate));
   }
 
-  function getCoverLiquidityAddedKey(bytes32 coverKey, address account) external pure returns (bytes32) {
-    return keccak256(abi.encodePacked(ProtoUtilV1.NS_COVER_LIQUIDITY_ADDED, coverKey, account));
-  }
-
   function getCoverLiquidityStakeKey(bytes32 coverKey) external pure returns (bytes32) {
     return keccak256(abi.encodePacked(ProtoUtilV1.NS_COVER_LIQUIDITY_STAKE, coverKey));
   }

--- a/contracts/libraries/ProtoUtilV1.sol
+++ b/contracts/libraries/ProtoUtilV1.sol
@@ -85,8 +85,6 @@ library ProtoUtilV1 {
   bytes32 public constant NS_COVER_LIQUIDITY_WITHDRAWAL_WINDOW = "ns:cover:liquidity:ww";
   bytes32 public constant NS_COVER_LIQUIDITY_MIN_STAKE = "ns:cover:liquidity:min:stake";
   bytes32 public constant NS_COVER_LIQUIDITY_STAKE = "ns:cover:liquidity:stake";
-  bytes32 public constant NS_COVER_LIQUIDITY_ADDED = "ns:cover:liquidity:add";
-  bytes32 public constant NS_COVER_LIQUIDITY_REMOVED = "ns:cover:liquidity:rem";
   bytes32 public constant NS_COVER_LIQUIDITY_COMMITTED = "ns:cover:liquidity:committed";
   bytes32 public constant NS_COVER_LIQUIDITY_NAME = "ns:cover:liquidityName";
   bytes32 public constant NS_COVER_REQUIRES_WHITELIST = "ns:cover:requires:whitelist";


### PR DESCRIPTION
- Refactored the codebase to drop maintaining individual account's liquidity added and removed states because you are now allowed to transfer PODs to a different wallet address and claim using that address.
- As a result of the above `_redeemPods` function now doesn't need to update the state and therefore the function name is changed to `_redeemPodCalculation` to signify that it is a read-only function or a view