### PR TITLE
Refactored NPM Token and Routine Invoker

### DIFF
--- a/contracts/core/delegates/VaultDelegateBase.sol
+++ b/contracts/core/delegates/VaultDelegateBase.sol
@@ -226,17 +226,16 @@ abstract contract VaultDelegateBase is IVaultDelegate, Recoverable {
 
   /**
    * @dev Gets information of a given vault by the cover key
+   * @param coverKey Specify cover key to obtain the info of.
    * @param you The address for which the info will be customized
    * @param values[0] totalPods --> Total PODs in existence
    * @param values[1] balance --> Stablecoins held in the vault
    * @param values[2] extendedBalance --> Stablecoins lent outside of the protocol
    * @param values[3] totalReassurance -- > Total reassurance for this cover
    * @param values[4] myPodBalance --> Your POD Balance
-   * @param values[5] myDeposits --> Sum of your deposits (in stablecoin)
-   * @param values[6] myWithdrawals --> Sum of your withdrawals  (in stablecoin)
-   * @param values[7] myShare --> My share of the liquidity pool (in stablecoin)
-   * @param values[8] withdrawalOpen --> The timestamp when withdrawals are opened
-   * @param values[9] withdrawalClose --> The timestamp when withdrawals are closed again
+   * @param values[5] myShare --> My share of the liquidity pool (in stablecoin)
+   * @param values[6] withdrawalOpen --> The timestamp when withdrawals are opened
+   * @param values[7] withdrawalClose --> The timestamp when withdrawals are closed again
    */
   function getInfoImplementation(bytes32 coverKey, address you) external view override returns (uint256[] memory values) {
     s.senderMustBeVaultContract(coverKey);

--- a/test/specs/liquidity/vault/add-liquidity.spec.js
+++ b/test/specs/liquidity/vault/add-liquidity.spec.js
@@ -31,6 +31,19 @@ describe('Vault: addLiquidity', () => {
     event.args.referralCode.should.equal(referralCode)
   })
 
+  it('correctly adds liquidity without NPM stake', async () => {
+    const coverKey = key.toBytes32('foo-bar')
+    const amount = '100'
+    const npmStake = helper.ether(0)
+    const referralCode = key.toBytes32('referral-code')
+
+    await deployed.npm.approve(deployed.vault.address, npmStake)
+    await deployed.dai.approve(deployed.vault.address, amount)
+
+    await deployed.vault.addLiquidity(coverKey, amount, npmStake, referralCode)
+      .should.not.be.rejected
+  })
+
   it('reverts when coverkey is invalid', async () => {
     const coverKey = key.toBytes32('foo-bar2')
     const amount = helper.ether(1_000)

--- a/test/specs/liquidity/vault/deps.js
+++ b/test/specs/liquidity/vault/deps.js
@@ -3,7 +3,11 @@ const { helper, deployer, key } = require('../../../../util')
 const pair = require('../../../../util/composer/uniswap-pair')
 const composer = require('../../../../util/composer')
 
-const DAYS = 86400
+const SECONDS = 1
+const MINUTES = 60 * SECONDS
+const HOURS = 60 * MINUTES
+const DAYS = 24 * HOURS
+
 const cache = null
 
 const deployDependencies = async () => {
@@ -134,7 +138,7 @@ const deployDependencies = async () => {
       helper.percentage(0.5), // Flash Loan Fee: 0.5%
       helper.percentage(2.5), // Flash Loan Protocol Fee: 2.5%
       1 * DAYS, // cooldown period,
-      1 * DAYS, // state and liquidity update interval
+      1 * SECONDS, // state and liquidity update interval
       helper.percentage(5) // maximum lending ratio
     ]
   )
@@ -329,6 +333,16 @@ const deployDependencies = async () => {
   await cover.addCover(coverKey, info, dai.address, requiresWhitelist, values)
   await cover.deployVault(coverKey)
 
+  const liquidityEngine = await deployer.deployWithLibraries(cache, 'LiquidityEngine', {
+    AccessControlLibV1: accessControlLibV1.address,
+    BaseLibV1: baseLibV1.address,
+    StoreKeyUtil: storeKeyUtil.address,
+    StrategyLibV1: strategyLibV1.address,
+    ValidationLibV1: validationLibV1.address
+  }, store.address)
+
+  await protocol.addContract(key.PROTOCOL.CNS.LIQUIDITY_ENGINE, liquidityEngine.address)
+
   const vault = await composer.vault.getVault({
     store: store,
     libs: {
@@ -371,7 +385,8 @@ const deployDependencies = async () => {
     reassuranceContract,
     governance,
     resolution,
-    vault
+    vault,
+    liquidityEngine
   }
 }
 

--- a/test/specs/liquidity/vault/remove-liquidity.spec.js
+++ b/test/specs/liquidity/vault/remove-liquidity.spec.js
@@ -1,9 +1,9 @@
 /* eslint-disable no-unused-expressions */
 const BigNumber = require('bignumber.js')
-const { network } = require('hardhat')
+const { ethers, network } = require('hardhat')
 const { helper, key } = require('../../../../util')
 const { deployDependencies } = require('./deps')
-const DAYS = 86400
+const HOURS = 60 * 60
 
 require('chai')
   .use(require('chai-as-promised'))
@@ -11,27 +11,66 @@ require('chai')
   .should()
 
 describe('Vault: removeLiquidity', () => {
-  let deployed
+  let deployed, coverKey, npmStake
 
-  before(async () => {
+  beforeEach(async () => {
     deployed = await deployDependencies()
+
+    coverKey = key.toBytes32('foo-bar')
+    const amount = helper.ether(10_000_000)
+    npmStake = helper.ether(500)
+    const referralCode = key.toBytes32('referral-code')
+
+    await deployed.npm.approve(deployed.vault.address, npmStake)
+    await deployed.dai.approve(deployed.vault.address, amount)
+
+    const lendingPeriod = 1 * HOURS
+    const withdrawalWindow = 1 * HOURS
+
+    await deployed.liquidityEngine.setLendingPeriods(coverKey, lendingPeriod, withdrawalWindow)
+
+    await deployed.vault.addLiquidity(coverKey, amount, npmStake, referralCode)
+
+    await network.provider.send('evm_increaseTime', [1 * HOURS])
+
+    await deployed.vault.accrueInterest()
+  })
+
+  it('successfully removes liquidity', async () => {
+    const [owner] = await ethers.getSigners()
+    const pods = helper.ether(2000)
+    await deployed.vault.approve(deployed.vault.address, pods)
+
+    const tx = await deployed.vault.removeLiquidity(coverKey, pods, npmStake, true)
+    const { events } = await tx.wait()
+
+    const event = events.find(x => x.event === 'PodsRedeemed')
+
+    event.args.account.should.equal(owner.address)
+    event.args.redeemed.should.equal(pods)
+    event.args.liquidityReleased.should.equal(pods)
+  })
+
+  it('successfully removes liquidity without NPM stake removal', async () => {
+    const pods = helper.ether(2000)
+    await deployed.vault.approve(deployed.vault.address, pods)
+
+    await deployed.vault.removeLiquidity(coverKey, pods, '0', false)
   })
 
   it('reverts when coverkey is invalid', async () => {
-    const coverKey = key.toBytes32('foo-bar2')
-    const amount = helper.ether(1_000)
-    const npmStake = helper.ether(500)
+    const pods = helper.ether(1_000)
+    await deployed.vault.approve(deployed.vault.address, pods)
 
-    await deployed.vault.removeLiquidity(coverKey, amount, npmStake, false)
+    await deployed.vault.removeLiquidity(key.toBytes32('foobar'), pods, npmStake, false)
       .should.be.rejectedWith('Forbidden')
   })
 
   it('reverts when invalid amount is supplied', async () => {
-    const coverKey = key.toBytes32('foo-bar')
-    const amount = helper.ether(0)
-    const npmStake = helper.ether(1)
+    const pods = helper.ether(0)
+    await deployed.vault.approve(deployed.vault.address, pods)
 
-    await deployed.vault.removeLiquidity(coverKey, amount, npmStake, false)
+    await deployed.vault.removeLiquidity(coverKey, pods, npmStake, false)
       .should.be.rejectedWith('Please specify amount')
   })
 })

--- a/test/specs/token/npm.spec.js
+++ b/test/specs/token/npm.spec.js
@@ -62,6 +62,27 @@ describe('NPM Token: Issuances', () => {
     const balance = await npm.balanceOf(owner.address)
     balance.should.equal(amount)
   })
+  it('should be reject if zero amount was specified', async () => {
+    const [owner, timelockOrOwner] = await ethers.getSigners()
+
+    const issuanceKey = key.toBytes32('Seed Round Investors')
+    const issueTo = owner.address
+    const amount = helper.ether(0)
+
+    await npm.connect(timelockOrOwner).issue(issuanceKey, issueTo, amount)
+      .should.be.rejectedWith('Invalid amount')
+  })
+
+  it('should revert if accessed by non-owner', async () => {
+    const [owner] = await ethers.getSigners()
+
+    const issuanceKey = key.toBytes32('Seed Round Investors')
+    const issueTo = owner.address
+    const amount = helper.ether(100_000_000)
+
+    await npm.issue(issuanceKey, issueTo, amount)
+      .should.be.rejectedWith('Ownable: caller is not the owner')
+  })
 
   it('should not exceed the cap', async () => {
     const [owner, timelockOrOwner] = await ethers.getSigners()
@@ -71,7 +92,7 @@ describe('NPM Token: Issuances', () => {
     const amount = ethers.BigNumber.from(helper.ether(900_000_000))
 
     await npm.connect(timelockOrOwner).issue(issuanceKey, issueTo, amount.add(1))
-      .should.be.rejectedWith('Error: can\'t exceed cap')
+      .should.be.rejectedWith('Cap exceeded')
   })
 
   it('should not allow issuances when paused', async () => {
@@ -84,6 +105,86 @@ describe('NPM Token: Issuances', () => {
     await npm.connect(timelockOrOwner).pause(true)
 
     await npm.connect(timelockOrOwner).issue(issuanceKey, issueTo, amount)
+      .should.be.rejectedWith('Pausable: paused')
+  })
+})
+
+describe('NPM Token: Issue Many', () => {
+  let npm
+
+  beforeEach(async () => {
+    const [, timelockOrOwner] = await ethers.getSigners()
+    npm = await deployer.deploy(cache, 'NPM', timelockOrOwner.address)
+  })
+
+  it('should issue to many accounts correctly', async () => {
+    const [, timelockOrOwner, alice, bob, charles, david, emily, frank] = await ethers.getSigners()
+
+    const issuanceKey = key.toBytes32('Seed Round Investors')
+    const receivers = [alice.address, bob.address, charles.address, david.address, emily.address, frank.address]
+    const amounts = [helper.ether(100), helper.ether(200), helper.ether(300), helper.ether(400), helper.ether(500), helper.ether(600)]
+
+    await npm.connect(timelockOrOwner).issueMany(issuanceKey, receivers, amounts)
+
+    for (const i in receivers) {
+      const balance = await npm.balanceOf(receivers[i])
+      balance.should.equal(amounts[i])
+    }
+  })
+
+  it('should revert if accessed by non-owner', async () => {
+    const [, , alice, bob, charles, david, emily, frank] = await ethers.getSigners()
+
+    const issuanceKey = key.toBytes32('Seed Round Investors')
+    const receivers = [alice.address, bob.address, charles.address, david.address, emily.address, frank.address]
+    const amounts = [helper.ether(100), helper.ether(200), helper.ether(300), helper.ether(400), helper.ether(500), helper.ether(600)]
+
+    await npm.issueMany(issuanceKey, receivers, amounts)
+      .should.be.rejectedWith('Ownable: caller is not the owner')
+  })
+
+  it('should revert when no account is supplied', async () => {
+    const [, timelockOrOwner] = await ethers.getSigners()
+
+    const issuanceKey = key.toBytes32('Seed Round Investors')
+    const receivers = []
+    const amounts = [helper.ether(100), helper.ether(200), helper.ether(300), helper.ether(400), helper.ether(500), helper.ether(600)]
+
+    await npm.connect(timelockOrOwner).issueMany(issuanceKey, receivers, amounts)
+      .should.be.rejectedWith('No receiver')
+  })
+
+  it('should revert when arguments have mismatch in number', async () => {
+    const [, timelockOrOwner, alice, bob, charles, david, emily, frank] = await ethers.getSigners()
+
+    const issuanceKey = key.toBytes32('Seed Round Investors')
+    const receivers = [alice.address, bob.address, charles.address, david.address, emily.address, frank.address]
+    const amounts = [helper.ether(100), helper.ether(200), helper.ether(300), helper.ether(400), helper.ether(500)]
+
+    await npm.connect(timelockOrOwner).issueMany(issuanceKey, receivers, amounts)
+      .should.be.rejectedWith('Invalid args')
+  })
+
+  it('should not exceed the cap', async () => {
+    const [, timelockOrOwner, alice, bob, charles] = await ethers.getSigners()
+
+    const issuanceKey = key.toBytes32('Seed Round Investors')
+    const receivers = [alice.address, bob.address, charles.address]
+    const amounts = [helper.ether(500_000_000), helper.ether(500_000_000), '1']
+
+    await npm.connect(timelockOrOwner).issueMany(issuanceKey, receivers, amounts)
+      .should.be.rejectedWith('Cap exceeded')
+  })
+
+  it('should not allow issuances when paused', async () => {
+    const [, timelockOrOwner, alice, bob, charles, david, emily, frank] = await ethers.getSigners()
+
+    const issuanceKey = key.toBytes32('Seed Round Investors')
+    const receivers = [alice.address, bob.address, charles.address, david.address, emily.address, frank.address]
+    const amounts = [helper.ether(100), helper.ether(200), helper.ether(300), helper.ether(400), helper.ether(500), helper.ether(600)]
+
+    await npm.connect(timelockOrOwner).pause(true)
+    await npm.connect(timelockOrOwner).issueMany(issuanceKey, receivers, amounts)
       .should.be.rejectedWith('Pausable: paused')
   })
 })
@@ -124,5 +225,74 @@ describe('NPM Token: Transfers', () => {
     await npm.connect(timelockOrOwner).pause(false)
 
     await npm.transfer(alice.address, helper.ether(2)).should.not.be.rejected
+  })
+})
+
+describe('NPM Token: Transfer Many', () => {
+  let npm
+
+  before(async () => {
+    const [, timelockOrOwner] = await ethers.getSigners()
+    npm = await deployer.deploy(cache, 'NPM', timelockOrOwner.address)
+
+    const issuanceKey = key.toBytes32('Seed Round Investors')
+    await npm.connect(timelockOrOwner).issue(issuanceKey, timelockOrOwner.address, helper.ether(1_000_000))
+  })
+
+  it('should transfer to many accounts correctly', async () => {
+    const [, timelockOrOwner, alice, bob, charles, david, emily, frank] = await ethers.getSigners()
+
+    const receivers = [alice.address, bob.address, charles.address, david.address, emily.address, frank.address]
+    const amounts = [helper.ether(100), helper.ether(200), helper.ether(300), helper.ether(400), helper.ether(500), helper.ether(600)]
+
+    await npm.connect(timelockOrOwner).transferMany(receivers, amounts)
+
+    for (const i in receivers) {
+      const balance = await npm.balanceOf(receivers[i])
+      balance.should.equal(amounts[i])
+    }
+  })
+
+  it('should revert if accessed by non-owner', async () => {
+    const [, timelockOrOwner, alice, bob, charles, david, emily, frank, george] = await ethers.getSigners()
+
+    const receivers = [alice.address, bob.address, charles.address, david.address, emily.address, frank.address]
+    const amounts = [helper.ether(100), helper.ether(200), helper.ether(300), helper.ether(400), helper.ether(500), helper.ether(600)]
+
+    await npm.connect(timelockOrOwner).issue(key.toBytes32('test'), george.address, helper.ether(1_000_000))
+
+    await npm.connect(george).transferMany(receivers, amounts)
+      .should.be.rejectedWith('Ownable: caller is not the owner')
+  })
+
+  it('should revert when no account is supplied', async () => {
+    const [, timelockOrOwner] = await ethers.getSigners()
+
+    const receivers = []
+    const amounts = [helper.ether(100), helper.ether(200), helper.ether(300), helper.ether(400), helper.ether(500), helper.ether(600)]
+
+    await npm.connect(timelockOrOwner).transferMany(receivers, amounts)
+      .should.be.rejectedWith('No receiver')
+  })
+
+  it('should revert when arguments have mismatch in number', async () => {
+    const [, timelockOrOwner, alice, bob, charles, david, emily, frank] = await ethers.getSigners()
+
+    const receivers = [alice.address, bob.address, charles.address, david.address, emily.address, frank.address]
+    const amounts = [helper.ether(100), helper.ether(200), helper.ether(300), helper.ether(400), helper.ether(500)]
+
+    await npm.connect(timelockOrOwner).transferMany(receivers, amounts)
+      .should.be.rejectedWith('Invalid args')
+  })
+
+  it('should not allow transferMany when paused', async () => {
+    const [, timelockOrOwner, alice, bob, charles, david, emily, frank] = await ethers.getSigners()
+
+    const receivers = [alice.address, bob.address, charles.address, david.address, emily.address, frank.address]
+    const amounts = [helper.ether(100), helper.ether(200), helper.ether(300), helper.ether(400), helper.ether(500), helper.ether(600)]
+
+    await npm.connect(timelockOrOwner).pause(true)
+    await npm.connect(timelockOrOwner).transferMany(receivers, amounts)
+      .should.be.rejectedWith('Pausable: paused')
   })
 })


### PR DESCRIPTION
- Added new features `issueMany` and `transferMany` to NPM token
- Split the functions `_executeIsWithdrawalPeriod` to two: `_isWithdrawalPeriod` and `_updateWithdrawalPeriod`.
- The `_updateWithdrawalPeriod` period still works without any strategy being present.
- Fixed mistake in documentation of `getInfoImplementation` in `VaultDelegateBase`
- Added more test cases