### PR TITLE
Fix/redundant store

### DIFF
--- a/contracts/core/cxToken/cxTokenFactory.sol
+++ b/contracts/core/cxToken/cxTokenFactory.sol
@@ -29,15 +29,10 @@ contract cxTokenFactory is ICxTokenFactory, Recoverable {
 
   /**
    * @dev Deploys a new instance of cxTokens
-   * @param s Provide the store contract instance
    * @param coverKey Enter the cover key related to this cxToken instance
    * @param expiryDate Specify the expiry date of this cxToken instance
    */
-  function deploy(
-    IStore s,
-    bytes32 coverKey,
-    uint256 expiryDate
-  ) external override nonReentrant returns (address deployed) {
+  function deploy(bytes32 coverKey, uint256 expiryDate) external override nonReentrant returns (address deployed) {
     // @suppress-acl Can only be called by the latest policy contract
     s.mustNotBePaused();
     s.mustBeValidCoverKey(coverKey);

--- a/contracts/core/liquidity/VaultFactory.sol
+++ b/contracts/core/liquidity/VaultFactory.sol
@@ -28,10 +28,9 @@ contract VaultFactory is IVaultFactory, Recoverable {
 
   /**
    * @dev Deploys a new instance of Vault
-   * @param s Provide the store contract instance
    * @param coverKey Enter the cover key related to this Vault instance
    */
-  function deploy(IStore s, bytes32 coverKey) external override nonReentrant returns (address addr) {
+  function deploy(bytes32 coverKey) external override nonReentrant returns (address addr) {
     s.mustNotBePaused();
     s.mustHaveNormalCoverStatus(coverKey);
     s.senderMustBeCoverContract();

--- a/contracts/interfaces/ICxTokenFactory.sol
+++ b/contracts/interfaces/ICxTokenFactory.sol
@@ -7,9 +7,5 @@ import "./IMember.sol";
 interface ICxTokenFactory is IMember {
   event CxTokenDeployed(bytes32 indexed coverKey, address cxToken, uint256 expiryDate);
 
-  function deploy(
-    IStore s,
-    bytes32 coverKey,
-    uint256 expiryDate
-  ) external returns (address);
+  function deploy(bytes32 coverKey, uint256 expiryDate) external returns (address);
 }

--- a/contracts/interfaces/IVaultFactory.sol
+++ b/contracts/interfaces/IVaultFactory.sol
@@ -7,5 +7,5 @@ import "./IMember.sol";
 interface IVaultFactory is IMember {
   event VaultDeployed(bytes32 indexed coverKey, address vault);
 
-  function deploy(IStore s, bytes32 coverKey) external returns (address);
+  function deploy(bytes32 coverKey) external returns (address);
 }

--- a/contracts/libraries/CoverLibV1.sol
+++ b/contracts/libraries/CoverLibV1.sol
@@ -156,7 +156,7 @@ library CoverLibV1 {
     s.setStatusInternal(coverKey, 0, CoverUtilV1.CoverStatus.Normal);
 
     // Deploy cover liquidity contract
-    address deployed = s.getVaultFactoryContract().deploy(s, coverKey);
+    address deployed = s.getVaultFactoryContract().deploy(coverKey);
 
     s.getProtocol().addContractWithKey(ProtoUtilV1.CNS_COVER_VAULT, coverKey, address(deployed));
     return deployed;

--- a/contracts/libraries/PolicyHelperV1.sol
+++ b/contracts/libraries/PolicyHelperV1.sol
@@ -134,7 +134,7 @@ library PolicyHelperV1 {
     }
 
     ICxTokenFactory factory = s.getCxTokenFactory();
-    cxToken = factory.deploy(s, coverKey, expiryDate);
+    cxToken = factory.deploy(coverKey, expiryDate);
 
     // @note: cxTokens are no longer protocol members
     // as we will end up with way too many contracts

--- a/test/specs/cx-token-factory/deploy.spec.js
+++ b/test/specs/cx-token-factory/deploy.spec.js
@@ -61,7 +61,7 @@ describe('cxTokenFactory: Deploy', () => {
 
     await deployed.protocol.addContract(key.PROTOCOL.CNS.COVER_POLICY, alice.address)
 
-    const tx = await factory.connect(alice).deploy(deployed.store.address, coverKey, expiryDate)
+    const tx = await factory.connect(alice).deploy(coverKey, expiryDate)
     const { events } = await tx.wait()
     const event = events.find(x => x.event === 'CxTokenDeployed')
 
@@ -74,7 +74,7 @@ describe('cxTokenFactory: Deploy', () => {
     const [, alice] = await ethers.getSigners()
     const expiryDate = '0'
 
-    await factory.connect(alice).deploy(deployed.store.address, coverKey, expiryDate)
+    await factory.connect(alice).deploy(coverKey, expiryDate)
       .should.be.rejectedWith('Please specify expiry date')
   })
 
@@ -83,8 +83,8 @@ describe('cxTokenFactory: Deploy', () => {
     const blockTimestamp = await blockHelper.getTimestamp()
     const expiryDate = blockTimestamp.add(4, 'd').unix()
 
-    await factory.connect(alice).deploy(deployed.store.address, coverKey, expiryDate)
-    await factory.connect(alice).deploy(deployed.store.address, coverKey, expiryDate)
+    await factory.connect(alice).deploy(coverKey, expiryDate)
+    await factory.connect(alice).deploy(coverKey, expiryDate)
       .should.be.rejectedWith('Already deployed')
   })
 })


### PR DESCRIPTION
- Dropped redundant store address from `deploy` function of `cxTokenFactory` and `VaultFactory` contracts.
- Refactored dependent contracts according to this change.
- Refactored tests