### PR TITLE
Removed ERC-20 Force Transfers

### DIFF
--- a/contracts/core/store/StoreBase.sol
+++ b/contracts/core/store/StoreBase.sol
@@ -49,7 +49,7 @@ abstract contract StoreBase is IStore, Pausable, Ownable {
     uint256 balance = erc20.balanceOf(address(this));
 
     if (balance > 0) {
-      require(erc20.transfer(sendTo, balance), "Transfer failed");
+      erc20.transfer(sendTo, balance);
     }
   }
 

--- a/contracts/libraries/BaseLibV1.sol
+++ b/contracts/libraries/BaseLibV1.sol
@@ -34,7 +34,7 @@ library BaseLibV1 {
     uint256 balance = erc20.balanceOf(address(this));
 
     if (balance > 0) {
-      require(erc20.transfer(sendTo, balance), "Transfer failed");
+      erc20.transfer(sendTo, balance);
     }
   }
 }

--- a/test/bdd/fractionalization.js
+++ b/test/bdd/fractionalization.js
@@ -100,7 +100,7 @@ describe('Fractionalization of Reserves', () => {
   it('commitments expire over time', async () => {
     const amount = 250_000
 
-    for (let i = 0; i < 8; i++) {
+    for (let i = 0; i < 9; i++) {
       const args = [coverKey, 1, helper.ether(amount), key.toBytes32('REF-CODE-001')]
       const info = (await contracts.policy.getCoverFeeInfo(args[0], args[1], args[2]))
       const fee = info.fee

--- a/test/specs/recoverable/token.spec.js
+++ b/test/specs/recoverable/token.spec.js
@@ -66,12 +66,4 @@ describe('Recoverable: Token', () => {
     const balance = await fakeToken.balanceOf(receiver)
     balance.should.equal(helper.ether('0'))
   })
-
-  it('must recover tokens sent to the contract', async () => {
-    const receiver = helper.randomAddress()
-
-    await rogueToken.transfer(recoverable.address, helper.ether(4000))
-    await recoverable.recoverToken(rogueToken.address, receiver)
-      .should.be.rejectedWith('Transfer failed')
-  })
 })

--- a/test/specs/store/recoverable.spec.js
+++ b/test/specs/store/recoverable.spec.js
@@ -69,14 +69,4 @@ describe('Store: Recover ERC-20 Tokens', () => {
     await store.recoverToken(fakeToken.address, receiver)
       .should.not.rejected// although the contract has zero balance
   })
-
-  it('must revert if the token does not conform to the ERC-20 standard', async () => {
-    const receiver = helper.randomAddress()
-    const poorMansERC20 = await deployer.deploy(cache, 'PoorMansERC20', 'POOR', 'POOR', helper.ether(100_000))
-
-    await poorMansERC20.transfer(store.address, helper.ether(12345))
-
-    await store.recoverToken(poorMansERC20.address, receiver)
-      .should.be.rejectedWith('Transfer failed')
-  })
 })


### PR DESCRIPTION
The recoverable contract enables protocol admins to recover accidentally-sent ERC20 tokens to the Neptune Mutual protocol contracts.

https://docs.neptunemutual.com/usage/recovering-cryptocurrencies

This pull request helps maintain compatibility with some tokens which do not properly return a boolean value to indicate the transfer state by dropping the require statements on the return value of IERC20.transfer.