### PR TITLE
Fixed `decreaseStake` issue

### DIFF
--- a/contracts/interfaces/ICoverStake.sol
+++ b/contracts/interfaces/ICoverStake.sol
@@ -4,8 +4,8 @@ pragma solidity 0.8.0;
 import "./IMember.sol";
 
 interface ICoverStake is IMember {
-  event StakeAdded(bytes32 indexed coverKey, uint256 amount);
-  event StakeRemoved(bytes32 indexed coverKey, uint256 amount);
+  event StakeAdded(bytes32 indexed coverKey, address indexed account, uint256 amount);
+  event StakeRemoved(bytes32 indexed coverKey, address indexed account, uint256 amount);
   event FeeBurned(bytes32 indexed coverKey, uint256 amount);
 
   /**
@@ -25,14 +25,9 @@ interface ICoverStake is IMember {
   /**
    * @dev Decreases the stake from the given cover pool
    * @param coverKey Enter the cover key
-   * @param account Enter the account to decrease the stake of
    * @param amount Enter the amount of stake to decrease
    */
-  function decreaseStake(
-    bytes32 coverKey,
-    address account,
-    uint256 amount
-  ) external;
+  function decreaseStake(bytes32 coverKey, uint256 amount) external;
 
   /**
    * @dev Gets the stake of an account for the given cover key

--- a/contracts/libraries/CoverLibV1.sol
+++ b/contracts/libraries/CoverLibV1.sol
@@ -150,6 +150,7 @@ library CoverLibV1 {
     // Set the fee charged during cover creation
     s.setUintByKeys(ProtoUtilV1.NS_COVER_FEE_EARNING, coverKey, fee);
 
+    s.setUintByKeys(ProtoUtilV1.NS_COVER_CREATION_DATE, coverKey, block.timestamp); // solhint-disable-line
     s.setUintByKeys(ProtoUtilV1.NS_GOVERNANCE_REPORTING_MIN_FIRST_STAKE, coverKey, values[2]);
     s.setUintByKeys(ProtoUtilV1.NS_GOVERNANCE_REPORTING_PERIOD, coverKey, values[3]);
     s.setUintByKeys(ProtoUtilV1.NS_RESOLUTION_COOL_DOWN_PERIOD, coverKey, values[4]);

--- a/contracts/libraries/CoverUtilV1.sol
+++ b/contracts/libraries/CoverUtilV1.sol
@@ -61,6 +61,10 @@ library CoverUtilV1 {
     return value;
   }
 
+  function getCoverCreationDate(IStore s, bytes32 coverKey) public view returns (uint256) {
+    return s.getUintByKeys(ProtoUtilV1.NS_COVER_CREATION_DATE, coverKey);
+  }
+
   function getMinStakeToAddLiquidity(IStore s) public view returns (uint256) {
     uint256 value = s.getUintByKey(ProtoUtilV1.NS_COVER_LIQUIDITY_MIN_STAKE);
 

--- a/contracts/libraries/ProtoUtilV1.sol
+++ b/contracts/libraries/ProtoUtilV1.sol
@@ -68,6 +68,7 @@ library ProtoUtilV1 {
   /// @dev Key prefix for creating a new cover product on chain
   bytes32 public constant NS_COVER = "ns:cover";
 
+  bytes32 public constant NS_COVER_CREATION_DATE = "ns:cover:creation:date";
   bytes32 public constant NS_COVER_CREATION_FEE = "ns:cover:creation:fee";
   bytes32 public constant NS_COVER_CREATION_MIN_STAKE = "ns:cover:creation:min:stake";
   bytes32 public constant NS_COVER_REASSURANCE = "ns:cover:reassurance";

--- a/util/ipfs.js
+++ b/util/ipfs.js
@@ -17,6 +17,8 @@ const write = async (contents, nodeUrls = fallbackNodes) => {
     return undefined
   }
 
+  console.info(`https://ipfs.neptunedefi.com/ipfs/${hash}`)
+
   return toBytes32(hash)
 }
 


### PR DESCRIPTION
- Persisted the cover creation timestamp when a new cover is created
- Refactored the `decreaseStake` function to make it publicly accessible
- Cover creators can optionally withdraw their full stake after 365 days of cover creation
- Refactored events `StakeAdded` and `StakeRemoved` to add “account” argument