### PR TITLE
Fix state update interval and  calculation of deposit amount for lending

### DIFF
--- a/contracts/libraries/RoutineInvokerLibV1.sol
+++ b/contracts/libraries/RoutineInvokerLibV1.sol
@@ -172,10 +172,10 @@ library RoutineInvokerLibV1 {
     uint256 totalStrategies,
     bytes32 coverKey
   ) private view returns (uint256) {
-    address vault = s.getVaultAddress(coverKey);
     IERC20 stablecoin = IERC20(s.getStablecoin());
 
-    uint256 maximumAllowed = (stablecoin.balanceOf(vault) * s.getMaxLendingRatioInternal()) / ProtoUtilV1.MULTIPLIER;
+    uint256 totalBalance = s.getStablecoinOwnedByVaultInternal(coverKey);
+    uint256 maximumAllowed = (totalBalance * s.getMaxLendingRatioInternal()) / ProtoUtilV1.MULTIPLIER;
     uint256 allocation = maximumAllowed / totalStrategies;
     uint256 weight = strategy.getWeight();
     uint256 canDeposit = (allocation * weight) / ProtoUtilV1.MULTIPLIER;
@@ -222,9 +222,10 @@ library RoutineInvokerLibV1 {
 
     if (action == Action.Withdraw) {
       _withdrawAllFromStrategy(strategy, vault, coverKey);
-    } else {
-      _depositToStrategy(strategy, coverKey, canDeposit);
+      return;
     }
+
+    _depositToStrategy(strategy, coverKey, canDeposit);
   }
 
   function _depositToStrategy(

--- a/scripts/config/network/mainnet.js
+++ b/scripts/config/network/mainnet.js
@@ -15,7 +15,7 @@ const config = {
       withdrawalWindow: 7 * DAYS,
       claimPeriod: 7 * DAYS,
       cooldownPeriod: 1 * DAYS,
-      stateUpdateInterval: 12 * HOURS
+      stateUpdateInterval: 1 * HOURS
     },
     knownAccounts: {
       admins: null


### PR DESCRIPTION
- Fixed calculation of `_canDeposit` amount to consider the amount of stablecoin already lent out to the strategies.
- Decreases the `stateUpdateInterval` time to 1 hour on `mainnet` so that token prices, withdrawal window are updated every one hour