### PR TITLE
Withdraw from Disabled

### DIFF
--- a/contracts/core/liquidity/LiquidityEngine.sol
+++ b/contracts/core/liquidity/LiquidityEngine.sol
@@ -41,6 +41,16 @@ contract LiquidityEngine is ILiquidityEngine, Recoverable {
     emit StrategyDisabled(strategy);
   }
 
+  function deleteStrategy(address strategy) external override nonReentrant {
+    // @suppress-address-trust-issue The address strategy can be trusted
+    // because this function can only be invoked by a liquidity manager.
+    s.mustNotBePaused();
+    AccessControlLibV1.mustBeLiquidityManager(s);
+
+    s.deleteStrategyInternal(strategy);
+    emit StrategyDeleted(strategy);
+  }
+
   function setLendingPeriods(
     bytes32 coverKey,
     uint256 lendingPeriod,

--- a/contracts/interfaces/ILiquidityEngine.sol
+++ b/contracts/interfaces/ILiquidityEngine.sol
@@ -8,6 +8,7 @@ pragma solidity 0.8.0;
 interface ILiquidityEngine is IMember {
   event StrategyAdded(address indexed strategy);
   event StrategyDisabled(address indexed strategy);
+  event StrategyDeleted(address indexed strategy);
   event LendingPeriodSet(bytes32 indexed coverKey, uint256 lendingPeriod, uint256 withdrawalWindow);
   event LiquidityStateUpdateIntervalSet(uint256 duration);
   event MaxLendingRatioSet(uint256 ratio);
@@ -15,6 +16,8 @@ interface ILiquidityEngine is IMember {
   function addStrategies(address[] memory strategies) external;
 
   function disableStrategy(address strategy) external;
+
+  function deleteStrategy(address strategy) external;
 
   function setLendingPeriods(
     bytes32 coverKey,

--- a/contracts/libraries/StrategyLibV1.sol
+++ b/contracts/libraries/StrategyLibV1.sol
@@ -24,6 +24,10 @@ library StrategyLibV1 {
     return keccak256(abi.encodePacked(ProtoUtilV1.NS_LENDING_STRATEGY_ACTIVE, strategyAddress));
   }
 
+  function _getIsDisabledStrategyKey(address strategyAddress) private pure returns (bytes32) {
+    return keccak256(abi.encodePacked(ProtoUtilV1.NS_LENDING_STRATEGY_DISABLED, strategyAddress));
+  }
+
   function disableStrategyInternal(IStore s, address toFind) external {
     // @suppress-address-trust-issue Check caller.
     _disableStrategy(s, toFind);
@@ -112,6 +116,7 @@ library StrategyLibV1 {
 
     s.deleteAddressArrayItem(key, toFind);
     s.setBoolByKey(_getIsActiveStrategyKey(toFind), false);
+    s.setBoolByKey(_getIsDisabledStrategyKey(toFind), true);
   }
 
   function _deleteStrategy(IStore s, address toFind) private {
@@ -121,6 +126,7 @@ library StrategyLibV1 {
     require(pos > 0, "Invalid strategy");
 
     s.deleteAddressArrayItem(key, toFind);
+    s.setBoolByKey(_getIsDisabledStrategyKey(toFind), false);
   }
 
   function getDisabledStrategiesInternal(IStore s) external view returns (address[] memory strategies) {

--- a/contracts/libraries/StrategyLibV1.sol
+++ b/contracts/libraries/StrategyLibV1.sol
@@ -26,9 +26,14 @@ library StrategyLibV1 {
 
   function disableStrategyInternal(IStore s, address toFind) external {
     // @suppress-address-trust-issue Check caller.
-    _deleteStrategy(s, toFind);
+    _disableStrategy(s, toFind);
 
     s.setAddressArrayByKey(ProtoUtilV1.NS_LENDING_STRATEGY_DISABLED, toFind);
+  }
+
+  function deleteStrategyInternal(IStore s, address toFind) external {
+    // @suppress-address-trust-issue Check caller.
+    _deleteStrategy(s, toFind);
   }
 
   function addStrategiesInternal(IStore s, address[] memory strategies) external {
@@ -99,7 +104,7 @@ library StrategyLibV1 {
     emit StrategyAdded(deployedOn);
   }
 
-  function _deleteStrategy(IStore s, address toFind) private {
+  function _disableStrategy(IStore s, address toFind) private {
     bytes32 key = ProtoUtilV1.NS_LENDING_STRATEGY_ACTIVE;
 
     uint256 pos = s.getAddressArrayItemPosition(key, toFind);
@@ -107,6 +112,15 @@ library StrategyLibV1 {
 
     s.deleteAddressArrayItem(key, toFind);
     s.setBoolByKey(_getIsActiveStrategyKey(toFind), false);
+  }
+
+  function _deleteStrategy(IStore s, address toFind) private {
+    bytes32 key = ProtoUtilV1.NS_LENDING_STRATEGY_DISABLED;
+
+    uint256 pos = s.getAddressArrayItemPosition(key, toFind);
+    require(pos > 0, "Invalid strategy");
+
+    s.deleteAddressArrayItem(key, toFind);
   }
 
   function getDisabledStrategiesInternal(IStore s) external view returns (address[] memory strategies) {

--- a/contracts/libraries/ValidationLibV1.sol
+++ b/contracts/libraries/ValidationLibV1.sol
@@ -135,8 +135,10 @@ library ValidationLibV1 {
   }
 
   function callerMustBeStrategyContract(IStore s, address caller) external view {
-    bool callerIsStrategyContract = s.getBoolByKey(_getIsActiveStrategyKey(caller));
-    require(callerIsStrategyContract == true, "Not a strategy contract");
+    bool isActive = s.getBoolByKey(_getIsActiveStrategyKey(caller));
+    bool wasDisabled = s.getBoolByKey(_getIsDisabledStrategyKey(caller));
+
+    require(isActive == true || wasDisabled == true, "Not a strategy contract");
   }
 
   function callerMustBeSpecificStrategyContract(
@@ -150,6 +152,10 @@ library ValidationLibV1 {
 
   function _getIsActiveStrategyKey(address strategyAddress) private pure returns (bytes32) {
     return keccak256(abi.encodePacked(ProtoUtilV1.NS_LENDING_STRATEGY_ACTIVE, strategyAddress));
+  }
+
+  function _getIsDisabledStrategyKey(address strategyAddress) private pure returns (bytes32) {
+    return keccak256(abi.encodePacked(ProtoUtilV1.NS_LENDING_STRATEGY_DISABLED, strategyAddress));
   }
 
   function senderMustBeProtocolMember(IStore s) external view {

--- a/contracts/libraries/ValidationLibV1.sol
+++ b/contracts/libraries/ValidationLibV1.sol
@@ -134,7 +134,7 @@ library ValidationLibV1 {
     require(senderIsStrategyContract == true, "Not a strategy contract");
   }
 
-  function callerMustBeStrategyContract(IStore s, address caller) external view {
+  function callerMustBeStrategyContract(IStore s, address caller) public view {
     bool isActive = s.getBoolByKey(_getIsActiveStrategyKey(caller));
     bool wasDisabled = s.getBoolByKey(_getIsDisabledStrategyKey(caller));
 
@@ -144,10 +144,10 @@ library ValidationLibV1 {
   function callerMustBeSpecificStrategyContract(
     IStore s,
     address caller,
-    bytes32 /*strategyName*/
+    bytes32 strategyName
   ) external view {
-    bool callerIsStrategyContract = s.getBoolByKey(_getIsActiveStrategyKey(caller));
-    require(callerIsStrategyContract == true, "Not a strategy contract");
+    callerMustBeStrategyContract(s, caller);
+    require(IMember(caller).getName() == strategyName, "Access denied");
   }
 
   function _getIsActiveStrategyKey(address strategyAddress) private pure returns (bytes32) {


### PR DESCRIPTION
- Added `deleteStrategy` feature in the `LiquidityEgnine` contract
- Updated `callerMustBeStrategyContract` to accept both active and disabled strategies