### PR TITLE
Updated `removeLiquidity` function in `VaultLiquidity`

### DIFF
--- a/contracts/core/liquidity/VaultLiquidity.sol
+++ b/contracts/core/liquidity/VaultLiquidity.sol
@@ -117,7 +117,6 @@ abstract contract VaultLiquidity is VaultBase {
     bool exit
   ) external override nonReentrant {
     require(coverKey == key, "Forbidden");
-    require(podsToRedeem > 0, "Please specify amount");
 
     /******************************************************************************************
       PRE

--- a/contracts/core/liquidity/VaultLiquidity.sol
+++ b/contracts/core/liquidity/VaultLiquidity.sol
@@ -117,6 +117,7 @@ abstract contract VaultLiquidity is VaultBase {
     bool exit
   ) external override nonReentrant {
     require(coverKey == key, "Forbidden");
+    require(podsToRedeem > 0 || npmStakeToRemove > 0, "Please specify pod amount or npm stake amount");
 
     /******************************************************************************************
       PRE


### PR DESCRIPTION
- removed `podsToRedeem > 0` requirement check from `removeLiquidity` function in `VaultLiquidity`
- ensure either `podsToRedeem` or `npmStakeToRemove` is greater than 0