### PR TITLE
Fix unstake after finalization

### DIFF
--- a/contracts/core/governance/resolution/Finalization.sol
+++ b/contracts/core/governance/resolution/Finalization.sol
@@ -81,6 +81,8 @@ abstract contract Finalization is Recoverable, IFinalization {
     bytes32 productKey,
     uint256 incidentDate
   ) internal {
+    s.setBoolByKey(GovernanceUtilV1.getHasFinalizedKeyInternal(coverKey, productKey, incidentDate), true);
+
     // Deleting latest incident date resets this product
     s.deleteUintByKeys(ProtoUtilV1.NS_GOVERNANCE_REPORTING_INCIDENT_DATE, coverKey, productKey);
     s.deleteUintByKeys(ProtoUtilV1.NS_GOVERNANCE_RESOLUTION_TS, coverKey, productKey);

--- a/contracts/libraries/GovernanceUtilV1.sol
+++ b/contracts/libraries/GovernanceUtilV1.sol
@@ -633,6 +633,20 @@ library GovernanceUtilV1 {
   }
 
   /**
+   * @dev Hash key of the "has finalized flag" for the specified cover product.
+   *
+   * Warning: this function does not validate the input arguments.
+   *
+   * @param coverKey Enter cover key
+   * @param productKey Enter product key
+   * @param incidentDate Enter incident date
+   *
+   */
+  function getHasFinalizedKeyInternal(bytes32 coverKey, bytes32 productKey, uint256 incidentDate) public pure returns (bytes32) {
+    return keccak256(abi.encodePacked(ProtoUtilV1.NS_GOVERNANCE_REPORTING_FINALIZATION, coverKey, productKey, incidentDate));
+  }
+
+  /**
    * @dev Returns sum total of NPM staken under `False Reporting` camp.
    *
    * Warning: this function does not validate the input arguments.

--- a/contracts/libraries/ProtoUtilV1.sol
+++ b/contracts/libraries/ProtoUtilV1.sol
@@ -161,6 +161,9 @@ library ProtoUtilV1 {
   /// @dev Used as key to flag if a cover was disputed. Cleared when a cover is finalized.
   bytes32 public constant NS_GOVERNANCE_REPORTING_HAS_A_DISPUTE = "ns:gov:rep:has:dispute";
 
+  /// @dev Used as key to flag if a incident was finalized.
+  bytes32 public constant NS_GOVERNANCE_REPORTING_FINALIZATION = "ns:gov:rep:has:finalized";
+
   /// @dev Used as key element in a couple of places:
   /// 1. For uint256 --> Sum total of NPM witnesses who disagreed with and disputed an incident reporting
   /// 2. For address --> The address of the first disputing reporter (disputer / candidate reporter)

--- a/contracts/libraries/ValidationLibV1.sol
+++ b/contracts/libraries/ValidationLibV1.sol
@@ -421,7 +421,6 @@ library ValidationLibV1 {
     mustNotBePaused(s);
     mustBeSupportedProductOrEmpty(s, coverKey, productKey);
     mustNotHaveUnstaken(s, msg.sender, coverKey, productKey, incidentDate);
-    mustBeAfterReportingPeriod(s, coverKey, productKey);
 
     // If this reporting gets finalized, incident date will become invalid
     // meaning this execution will revert thereby restricting late comers
@@ -432,14 +431,6 @@ library ValidationLibV1 {
     // Before the deadline, emergency resolution can still happen
     // that may have an impact on the final decision. We, therefore, have to wait.
     mustBeAfterResolutionDeadline(s, coverKey, productKey);
-
-    bool incidentHappened = s.getProductStatusOfInternal(coverKey, productKey, incidentDate) == CoverUtilV1.ProductStatus.Claimable;
-
-    if (incidentHappened) {
-      // Incident occurred. Must unstake with claim during the claim period.
-      mustBeDuringClaimPeriod(s, coverKey, productKey);
-      return;
-    }
   }
 
   function mustBeDuringClaimPeriod(

--- a/contracts/libraries/ValidationLibV1.sol
+++ b/contracts/libraries/ValidationLibV1.sol
@@ -288,6 +288,15 @@ library ValidationLibV1 {
     require(deadline > 0 && block.timestamp > deadline, "Still unresolved"); // solhint-disable-line
   }
 
+  function mustBeAfterFinalization(
+    IStore s,
+    bytes32 coverKey,
+    bytes32 productKey,
+    uint256 incidentDate
+  ) public view {
+    require(s.getBoolByKey(GovernanceUtilV1.getHasFinalizedKeyInternal(coverKey, productKey, incidentDate)), "Incident not finalized");
+  }
+
   function mustBeValidIncidentDate(
     IStore s,
     bytes32 coverKey,
@@ -393,11 +402,7 @@ library ValidationLibV1 {
     mustNotBePaused(s);
     mustBeSupportedProductOrEmpty(s, coverKey, productKey);
     mustNotHaveUnstaken(s, msg.sender, coverKey, productKey, incidentDate);
-    mustBeAfterReportingPeriod(s, coverKey, productKey);
-
-    // Before the deadline, emergency resolution can still happen
-    // that may have an impact on the final decision. We, therefore, have to wait.
-    mustBeAfterResolutionDeadline(s, coverKey, productKey);
+    mustBeAfterFinalization(s, coverKey, productKey, incidentDate);
   }
 
   /**

--- a/test/specs/governance/resolution/unstake-with-claim.spec.js
+++ b/test/specs/governance/resolution/unstake-with-claim.spec.js
@@ -174,6 +174,8 @@ describe('Resolution: unstakeWithClaim (incident occurred)', () => {
     await network.provider.send('evm_increaseTime', [7 * DAYS])
     await network.provider.send('evm_increaseTime', [1])
 
+    await deployed.resolution.unstake(coverKey, helper.emptyBytes32, incidentDate)
+      .should.be.rejectedWith('Incident not finalized')
     await deployed.resolution.unstakeWithClaim(coverKey, helper.emptyBytes32, incidentDate)
       .should.be.rejectedWith('Claim period has expired')
 


### PR DESCRIPTION
Fix the error which disallowed winning camp to unstake their NPM after finalization

If the incident report is resolved as "incident occurred", then after the resolution deadline the winning camp can
- `unstakeWithClaim` before finalization
- `unstake` after finalization

If the incident report is resolved as "false reporting", then after the resolution deadline the winning camp can
- `unstakeWithClaim` before finalization
- `unstake` after finalization