### PR TITLE
Fixes Issue #134 - Conflated staking pool reward balances

### DIFF
--- a/contracts/libraries/StakingPoolLibV1.sol
+++ b/contracts/libraries/StakingPoolLibV1.sol
@@ -151,13 +151,6 @@ library StakingPoolLibV1 {
     return s.getUintByKeys(StakingPoolCoreLibV1.NS_POOL_REWARD_HEIGHTS, key, account);
   }
 
-  function getStakingPoolRewardTokenBalance(IStore s, bytes32 key) public view returns (uint256) {
-    IERC20 rewardToken = IERC20(s.getAddressByKeys(StakingPoolCoreLibV1.NS_POOL_REWARD_TOKEN, key));
-    address stakingPool = s.getStakingPoolAddress();
-
-    return rewardToken.balanceOf(stakingPool);
-  }
-
   function calculateRewardsInternal(
     IStore s,
     bytes32 key,
@@ -173,7 +166,7 @@ library StakingPoolLibV1 {
     uint256 myStake = getAccountStakingBalanceInternal(s, key, account);
     uint256 rewards = (myStake * rewardPerBlock * totalBlocks) / 1 ether;
 
-    uint256 poolBalance = getStakingPoolRewardTokenBalance(s, key);
+    uint256 poolBalance = s.getRewardTokenBalance(key);
 
     return rewards > poolBalance ? poolBalance : rewards;
   }


### PR DESCRIPTION
- Fixes #134
- Refactored `calculateRewardsInternal` to consider the reward token of the pool with given `key` instead of the reward token balance of `StakingPools.sol` contract