### PR TITLE
Fixes Issue #148 - Incorrect NPM threshold

### DIFF
--- a/contracts/libraries/ProtoUtilV1.sol
+++ b/contracts/libraries/ProtoUtilV1.sol
@@ -15,9 +15,9 @@ library ProtoUtilV1 {
   bytes32 public constant KEY_INTENTIONALLY_EMPTY = 0;
   bytes32 public constant PRODUCT_KEY_INTENTIONALLY_EMPTY = 0;
   uint256 public constant MULTIPLIER = 10_000;
-  uint256 public constant MAX_LIQUIDITY = 10_000_000_000;
-  uint256 public constant MAX_PROPOSAL_AMOUNT = 10_000_000_000;
-  uint256 public constant MAX_NPM_STAKE = 10_000_000_000;
+  uint256 public constant MAX_LIQUIDITY = 10_000_000;
+  uint256 public constant MAX_PROPOSAL_AMOUNT = 10_000_000;
+  uint256 public constant MAX_NPM_STAKE = 10_000_000;
   uint256 public constant NPM_PRECISION = 1 ether;
   uint256 public constant CXTOKEN_PRECISION = 1 ether;
   uint256 public constant POD_PRECISION = 1 ether;

--- a/test/stories/1. policy.spec.js
+++ b/test/stories/1. policy.spec.js
@@ -29,7 +29,7 @@ describe('Policy Purchase Stories', () => {
     // console.info(`https://ipfs.infura.io/ipfs/${ipfs.toIPFShash(info)}`)
 
     const initialReassuranceAmount = helper.ether(1_000_000, PRECISION)
-    const initialLiquidity = helper.ether(24_000_000, PRECISION)
+    const initialLiquidity = helper.ether(4_000_000, PRECISION)
     const stakeWithFee = helper.ether(10_000)
     const minReportingStake = helper.ether(250)
     const reportingPeriod = 7 * DAYS
@@ -57,7 +57,7 @@ describe('Policy Purchase Stories', () => {
     const result = await contracts.policy.getCoverPoolSummary(coverKey, helper.emptyBytes32)
     const [totalAmountInPool, totalCommitment, reassurance, reassuranceWeight, count, leverage, efficiency] = result
 
-    totalAmountInPool.toString().should.equal(helper.ether(24_000_000, PRECISION))
+    totalAmountInPool.toString().should.equal(helper.ether(4_000_000, PRECISION))
     totalCommitment.toString().should.equal('0')
     reassurance.toString().should.equal(helper.ether(1_000_000, PRECISION))
     reassuranceWeight.toString().should.equal(helper.percentage(100))


### PR DESCRIPTION
Updated thresholds to 10 million - `MAX_LIQUIDITY`, `MAX_PROPOSAL_AMOUNT` and `MAX_NPM_STAKE`