### PR TITLE
Fixes Issue #153 - The info parameter might lose information about an IPFS hash

### DIFF
--- a/contracts/core/governance/Reporter.sol
+++ b/contracts/core/governance/Reporter.sol
@@ -124,7 +124,7 @@ abstract contract Reporter is IReporter, Witness {
   function report(
     bytes32 coverKey,
     bytes32 productKey,
-    bytes32 info,
+    string calldata info,
     uint256 stake
   ) external override nonReentrant {
     s.mustNotBePaused();
@@ -201,7 +201,7 @@ abstract contract Reporter is IReporter, Witness {
     bytes32 coverKey,
     bytes32 productKey,
     uint256 incidentDate,
-    bytes32 info,
+    string calldata info,
     uint256 stake
   ) external override nonReentrant {
     s.mustNotBePaused();

--- a/contracts/core/lifecycle/Cover.sol
+++ b/contracts/core/lifecycle/Cover.sol
@@ -65,7 +65,7 @@ contract Cover is CoverBase {
    */
   function addCover(
     bytes32 coverKey,
-    bytes32 info,
+    string calldata info,
     string calldata tokenName,
     string calldata tokenSymbol,
     bool supportsProducts,
@@ -95,13 +95,13 @@ contract Cover is CoverBase {
    * @param info IPFS hash. Check out the [documentation](https://docs.neptunemutual.com/sdk/managing-covers) for more info.
    *
    */
-  function updateCover(bytes32 coverKey, bytes32 info) external override nonReentrant {
+  function updateCover(bytes32 coverKey, string calldata info) external override nonReentrant {
     s.mustNotBePaused();
     s.mustEnsureAllProductsAreNormal(coverKey);
     AccessControlLibV1.mustBeCoverManager(s);
     s.mustBeDuringWithdrawalPeriod(coverKey);
 
-    require(s.getBytes32ByKeys(ProtoUtilV1.NS_COVER_INFO, coverKey) != info, "Duplicate content");
+    require(keccak256(bytes(s.getStringByKeys(ProtoUtilV1.NS_COVER_INFO, coverKey))) != keccak256(bytes(info)), "Duplicate content");
 
     s.updateCoverInternal(coverKey, info);
     emit CoverUpdated(coverKey, info);
@@ -123,7 +123,7 @@ contract Cover is CoverBase {
   function addProduct(
     bytes32 coverKey,
     bytes32 productKey,
-    bytes32 info,
+    string calldata info,
     bool requiresWhitelist,
     uint256[] calldata values
   ) external override {
@@ -142,7 +142,7 @@ contract Cover is CoverBase {
    *
    * @param coverKey Enter the cover key
    * @param productKey Enter the product key
-   * @param info Enter a new IPFS URL to update
+   * @param info Enter a new IPFS hash to update
    * @param values[0] Product status
    * @param values[1] Enter the capital efficiency ratio in percentage value (Check ProtoUtilV1.MULTIPLIER for division)
    *
@@ -150,7 +150,7 @@ contract Cover is CoverBase {
   function updateProduct(
     bytes32 coverKey,
     bytes32 productKey,
-    bytes32 info,
+    string calldata info,
     uint256[] calldata values
   ) external override {
     // @suppress-zero-value-check The uint values are validated in the function `updateProductInternal`

--- a/contracts/interfaces/ICover.sol
+++ b/contracts/interfaces/ICover.sol
@@ -4,10 +4,10 @@ pragma solidity ^0.8.0;
 import "./IMember.sol";
 
 interface ICover is IMember {
-  event CoverCreated(bytes32 indexed coverKey, bytes32 info, string tokenName, string tokenSymbol, bool indexed supportsProducts, bool indexed requiresWhitelist);
-  event ProductCreated(bytes32 indexed coverKey, bytes32 productKey, bytes32 info, bool requiresWhitelist, uint256[] values);
-  event CoverUpdated(bytes32 indexed coverKey, bytes32 info);
-  event ProductUpdated(bytes32 indexed coverKey, bytes32 productKey, bytes32 info, uint256[] values);
+  event CoverCreated(bytes32 indexed coverKey, string info, string tokenName, string tokenSymbol, bool indexed supportsProducts, bool indexed requiresWhitelist);
+  event ProductCreated(bytes32 indexed coverKey, bytes32 productKey, string info, bool requiresWhitelist, uint256[] values);
+  event CoverUpdated(bytes32 indexed coverKey, string info);
+  event ProductUpdated(bytes32 indexed coverKey, bytes32 productKey, string info, uint256[] values);
   event ProductStateUpdated(bytes32 indexed coverKey, bytes32 indexed productKey, address indexed updatedBy, bool status, string reason);
   event VaultDeployed(bytes32 indexed coverKey, address vault);
 
@@ -57,7 +57,7 @@ interface ICover is IMember {
    */
   function addCover(
     bytes32 coverKey,
-    bytes32 info,
+    string calldata info,
     string calldata tokenName,
     string calldata tokenSymbol,
     bool supportsProducts,
@@ -68,7 +68,7 @@ interface ICover is IMember {
   function addProduct(
     bytes32 coverKey,
     bytes32 productKey,
-    bytes32 info,
+    string calldata info,
     bool requiresWhitelist,
     uint256[] calldata values
   ) external;
@@ -76,7 +76,7 @@ interface ICover is IMember {
   function updateProduct(
     bytes32 coverKey,
     bytes32 productKey,
-    bytes32 info,
+    string calldata info,
     uint256[] calldata values
   ) external;
 
@@ -85,9 +85,9 @@ interface ICover is IMember {
    * This feature is accessible only to the cover owner or protocol owner (governance).
    *
    * @param coverKey Enter the cover key
-   * @param info Enter a new IPFS URL to update
+   * @param info Enter a new IPFS hash to update
    */
-  function updateCover(bytes32 coverKey, bytes32 info) external;
+  function updateCover(bytes32 coverKey, string calldata info) external;
 
   function updateCoverCreatorWhitelist(address account, bool whitelisted) external;
 

--- a/contracts/interfaces/IReporter.sol
+++ b/contracts/interfaces/IReporter.sol
@@ -3,8 +3,8 @@
 pragma solidity ^0.8.0;
 
 interface IReporter {
-  event Reported(bytes32 indexed coverKey, bytes32 indexed productKey, address reporter, uint256 indexed incidentDate, bytes32 info, uint256 initialStake, uint256 resolutionTimestamp);
-  event Disputed(bytes32 indexed coverKey, bytes32 indexed productKey, address reporter, uint256 indexed incidentDate, bytes32 info, uint256 initialStake);
+  event Reported(bytes32 indexed coverKey, bytes32 indexed productKey, address reporter, uint256 indexed incidentDate, string info, uint256 initialStake, uint256 resolutionTimestamp);
+  event Disputed(bytes32 indexed coverKey, bytes32 indexed productKey, address reporter, uint256 indexed incidentDate, string info, uint256 initialStake);
 
   event ReportingBurnRateSet(uint256 previous, uint256 current);
   event FirstReportingStakeSet(bytes32 coverKey, uint256 previous, uint256 current);
@@ -13,7 +13,7 @@ interface IReporter {
   function report(
     bytes32 coverKey,
     bytes32 productKey,
-    bytes32 info,
+    string calldata info,
     uint256 stake
   ) external;
 
@@ -21,7 +21,7 @@ interface IReporter {
     bytes32 coverKey,
     bytes32 productKey,
     uint256 incidentDate,
-    bytes32 info,
+    string calldata info,
     uint256 stake
   ) external;
 

--- a/contracts/libraries/StoreKeyUtil.sol
+++ b/contracts/libraries/StoreKeyUtil.sol
@@ -117,6 +117,16 @@ library StoreKeyUtil {
     return s.setString(_getKey(key1, key2), value);
   }
 
+  function setStringByKeys(
+    IStore s,
+    bytes32 key1,
+    bytes32 key2,
+    bytes32 key3,
+    string calldata value
+  ) external {
+    return s.setString(_getKey(key1, key2, key3), value);
+  }
+
   function setBytes32ByKey(
     IStore s,
     bytes32 key,

--- a/util/composer/covers.js
+++ b/util/composer/covers.js
@@ -28,7 +28,7 @@ const addCover = async (payload, info) => {
 
   const { key, leverage, supportsProducts } = info
   const { minReportingStake, reportingPeriod, stakeWithFees, reassurance, cooldownPeriod, claimPeriod, pricingFloor, pricingCeiling, requiresWhitelist, reassuranceRate, vault } = info
-  const hashBytes32 = await ipfs.write(info)
+  const ipfsHash = await ipfs.write(info)
 
   const values = [
     stakeWithFees.toString(),
@@ -43,7 +43,7 @@ const addCover = async (payload, info) => {
     leverage.toString()
   ]
 
-  await intermediate(cache, cover, 'addCover', key, hashBytes32, vault.name, vault.symbol, supportsProducts, requiresWhitelist, values)
+  await intermediate(cache, cover, 'addCover', key, ipfsHash, vault.name, vault.symbol, supportsProducts, requiresWhitelist, values)
   await rest(100)
 }
 
@@ -52,7 +52,7 @@ const addProduct = async (payload, info) => {
   const { cover } = contracts
 
   const { coverKey, productKey, requiresWhitelist, capitalEfficiency } = info
-  const hashBytes32 = await ipfs.write(info)
+  const ipfsHash = await ipfs.write(info)
 
   const status = 1
 
@@ -61,7 +61,7 @@ const addProduct = async (payload, info) => {
     capitalEfficiency
   ]
 
-  await intermediate(cache, cover, 'addProduct', coverKey, productKey, hashBytes32, requiresWhitelist, values)
+  await intermediate(cache, cover, 'addProduct', coverKey, productKey, ipfsHash, requiresWhitelist, values)
 }
 
 module.exports = { createCovers }

--- a/util/ipfs.js
+++ b/util/ipfs.js
@@ -2,14 +2,14 @@ const axios = require('axios')
 
 const write = async (contents) => {
   const { data } = await axios.put(process.env.NPM_IPFS_API_URL, contents)
-  const { bytes32Hash, hash } = data
+  const { hash } = data
 
   // June 22 Security Review: use an entirely different domain for
   // hosting IPFS server to avoid phishing attacks on the
   // Neptune Mutual domain(s)
   console.info(process.env.IPFS_GATEWAY, hash)
 
-  return bytes32Hash
+  return hash
 }
 
 module.exports = { write }


### PR DESCRIPTION
- Refactored all instances of `IPFS info` object to use `string` instead of `bytes32`
- Moved the IPFS info length validation to `_addCover` from `_validateAndGetFee`
- Renamed the function `_validateAndGetFee` to `_getFee`
- Refactored JavaScript test helper modules to plain IPFS hash