### PR TITLE
Fixes Issue #147 - Imprecise bounds

### DIFF
--- a/contracts/libraries/RoutineInvokerLibV1.sol
+++ b/contracts/libraries/RoutineInvokerLibV1.sol
@@ -158,7 +158,7 @@ library RoutineInvokerLibV1 {
     uint256 end = s.getUintByKey(getNextWithdrawalEndKey(coverKey));
 
     require(start > 0 && block.timestamp >= start, "Withdrawal period has not started");
-    require(end > 0 && block.timestamp < end, "Withdrawal period has already ended");
+    require(end > 0 && block.timestamp <= end, "Withdrawal period has already ended");
   }
 
   function _executeAndGetAction(

--- a/contracts/libraries/StakingPoolLibV1.sol
+++ b/contracts/libraries/StakingPoolLibV1.sol
@@ -282,7 +282,7 @@ library StakingPoolLibV1 {
     require(amount > 0, "Please specify amount");
 
     require(getAccountStakingBalanceInternal(s, key, msg.sender) >= amount, "Insufficient balance");
-    require(block.number > canWithdrawFromBlockHeightInternal(s, key, msg.sender), "Withdrawal too early");
+    require(block.number >= canWithdrawFromBlockHeightInternal(s, key, msg.sender), "Withdrawal too early");
 
     stakingToken = s.getStakingTokenAddressInternal(key);
 

--- a/contracts/libraries/ValidationLibV1.sol
+++ b/contracts/libraries/ValidationLibV1.sol
@@ -285,7 +285,7 @@ library ValidationLibV1 {
     bytes32 productKey
   ) public view {
     uint256 deadline = s.getResolutionDeadlineInternal(coverKey, productKey);
-    require(deadline > 0 && block.timestamp > deadline, "Still unresolved"); // solhint-disable-line
+    require(deadline > 0 && block.timestamp >= deadline, "Still unresolved"); // solhint-disable-line
   }
 
   function mustBeAfterFinalization(

--- a/contracts/libraries/VaultLibV1.sol
+++ b/contracts/libraries/VaultLibV1.sol
@@ -303,7 +303,7 @@ library VaultLibV1 {
     If the token is not supported flashFee MUST revert.
     */
     require(stablecoin == token, "Unsupported token");
-    require(IERC20(stablecoin).balanceOf(s.getVaultAddress(coverKey)) > amount, "Amount insufficient");
+    require(IERC20(stablecoin).balanceOf(s.getVaultAddress(coverKey)) >= amount, "Amount insufficient");
 
     uint256 rate = _getFlashLoanFeeRateInternal(s);
     uint256 protocolRate = _getProtocolFlashLoanFeeRateInternal(s);


### PR DESCRIPTION
- Refactored `mustBeDuringWithdrawalPeriod` to consider the `end` timestamp to be part of the withdrawal period
- Refactored `withdrawInternal` to allow withdrawals on block height where withdrawals can start
- Refactored `mustBeAfterResolutionDeadline` to succeed on the resolution deadline timestamp
- Refactored `getFlashFeesInternal` to allow lending of whole stablecoin balance of the vault

Fixes #147