### PR TITLE
Fixes Issue #152 - Protocol administrator needs to handle external tokens

### DIFF
--- a/contracts/pool/Bond/BondPoolBase.sol
+++ b/contracts/pool/Bond/BondPoolBase.sol
@@ -51,7 +51,7 @@ abstract contract BondPoolBase is IBondPool, Recoverable {
   function setup(address[] calldata addresses, uint256[] calldata values) external override nonReentrant {
     // @suppress-zero-value-check The uint values are checked in the function `setupBondPoolInternal`
     s.mustNotBePaused();
-    AccessControlLibV1.mustBeAdmin(s);
+    AccessControlLibV1.mustBeLiquidityManager(s);
 
     s.setupBondPoolInternal(addresses, values);
 

--- a/contracts/pool/Staking/StakingPoolBase.sol
+++ b/contracts/pool/Staking/StakingPoolBase.sol
@@ -43,7 +43,7 @@ abstract contract StakingPoolBase is IStakingPools, Recoverable {
   ) external override nonReentrant {
     // @suppress-zero-value-check The uint values are checked in the function `addOrEditPoolInternal`
     s.mustNotBePaused();
-    AccessControlLibV1.mustBeAdmin(s);
+    AccessControlLibV1.mustBeLiquidityManager(s);
 
     s.addOrEditPoolInternal(key, name, addresses, values);
     emit PoolUpdated(key, name, poolType, addresses[0], addresses[1], addresses[2], addresses[3], values[5], values[1], values[3], values[4], values[2], values[0]);
@@ -51,7 +51,7 @@ abstract contract StakingPoolBase is IStakingPools, Recoverable {
 
   function closePool(bytes32 key) external override nonReentrant {
     s.mustNotBePaused();
-    AccessControlLibV1.mustBeAdmin(s);
+    AccessControlLibV1.mustBeLiquidityManager(s);
     require(s.getBoolByKeys(StakingPoolCoreLibV1.NS_POOL, key), "Unknown Pool");
     require(s.getPoolStakeBalanceInternal(key) == 0, "Pool is not empty");
 


### PR DESCRIPTION
- Replaced `admin` with `liquidity manager` on `addOrEditPool` and `closePool` functions of the StakingPoolBase contract.
- Replaced `admin` with `liquidity manager` on `setup` function of the BondPoolBase contract.