### PR TITLE
Fixes Issue #174 - transfer and send calls are no longer considered best practice

### DIFF
--- a/contracts/core/store/StoreBase.sol
+++ b/contracts/core/store/StoreBase.sol
@@ -58,7 +58,8 @@ abstract contract StoreBase is IStore, Pausable, Ownable {
    */
   function recoverEther(address sendTo) external onlyOwner {
     // slither-disable-next-line arbitrary-send
-    payable(sendTo).transfer(address(this).balance);
+    (bool success, ) = payable(sendTo).call{value: address(this).balance}(""); // solhint-disable-line avoid-low-level-calls
+    require(success, "Recipient may have reverted");
   }
 
   /**

--- a/contracts/core/token/WithRecovery.sol
+++ b/contracts/core/token/WithRecovery.sol
@@ -16,7 +16,8 @@ abstract contract WithRecovery is Ownable {
    */
   function recoverEther(address sendTo) external onlyOwner {
     // slither-disable-next-line arbitrary-send
-    payable(sendTo).transfer(address(this).balance);
+    (bool success, ) = payable(sendTo).call{value: address(this).balance}(""); // solhint-disable-line avoid-low-level-calls
+    require(success, "Recipient may have reverted");
   }
 
   /**

--- a/contracts/libraries/BaseLibV1.sol
+++ b/contracts/libraries/BaseLibV1.sol
@@ -20,7 +20,8 @@ library BaseLibV1 {
    */
   function recoverEtherInternal(address sendTo) external {
     // slither-disable-next-line arbitrary-send
-    payable(sendTo).transfer(address(this).balance);
+    (bool success, ) = payable(sendTo).call{value: address(this).balance}(""); // solhint-disable-line avoid-low-level-calls
+    require(success, "Recipient may have reverted");
   }
 
   /**


### PR DESCRIPTION
- Replaced transfer calls with`address.call{value: amount}("")` to send ether