### PR TITLE
# Miscellaneous Refactor and Fixes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -70,7 +70,20 @@
     "unstake",
     "Unstaken",
     "WXDAI",
-    "zerox"
+    "zerox",
+    "staker",
+    "stakers",
+    "unstake",
+    "unstaking",
+    "unstakable",
+    "unstakewithclaim",
+    "ndai",
+    "nusdc",
+    "unpause",
+    "unpauser",
+    "uint",
+    "uints",
+    "finalizer"
   ],
   "git.detectSubmodules": false
 }

--- a/contracts/core/ProtoBase.sol
+++ b/contracts/core/ProtoBase.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.0;
 import "openzeppelin-solidity/contracts/access/AccessControl.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
 import "openzeppelin-solidity/contracts/security/Pausable.sol";
-import "../libraries/ProtoUtilV1.sol";
 import "./Recoverable.sol";
 
 abstract contract ProtoBase is AccessControl, Pausable, Recoverable {

--- a/contracts/core/Protocol.sol
+++ b/contracts/core/Protocol.sol
@@ -155,9 +155,6 @@ contract Protocol is IProtocol, ProtoBase {
    * Since adding member to the protocol is a highly risky activity,
    * the role `Upgrade Agent` is considered to be one of the most `Critical` roles.
    *
-   * Using Tenderly War Rooms/Web3 Actions or OZ Defender, the protocol needs to be paused
-   * when this function is invoked.
-   *
    * @custom:suppress-address-trust-issue Although the `contractAddress` can't be trusted,
    * an upgrade admin has to check the contract code manually.
    *
@@ -209,9 +206,6 @@ contract Protocol is IProtocol, ProtoBase {
    * This feature is only accessible to an upgrade agent.
    * Since adding member to the protocol is a highly risky activity,
    * the role `Upgrade Agent` is considered to be one of the most `Critical` roles.
-   *
-   * Using Tenderly War Rooms/Web3 Actions or OZ Defender, the protocol needs to be paused
-   * when this function is invoked.
    *
    * @custom:suppress-address-trust-issue Can only be invoked by an upgrade agent.
    *

--- a/contracts/core/Protocol.sol
+++ b/contracts/core/Protocol.sol
@@ -1,18 +1,16 @@
 // Neptune Mutual Protocol (https://neptunemutual.com)
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.0;
+import "./ProtoBase.sol";
 import "../interfaces/IStore.sol";
 import "../interfaces/IProtocol.sol";
-import "../libraries/ProtoUtilV1.sol";
-import "../libraries/StoreKeyUtil.sol";
-import "./ProtoBase.sol";
 
 contract Protocol is IProtocol, ProtoBase {
   using ProtoUtilV1 for bytes;
-  using RegistryLibV1 for IStore;
   using ProtoUtilV1 for IStore;
-  using ValidationLibV1 for IStore;
+  using RegistryLibV1 for IStore;
   using StoreKeyUtil for IStore;
+  using ValidationLibV1 for IStore;
 
   bool public initialized = false;
 
@@ -48,6 +46,8 @@ contract Protocol is IProtocol, ProtoBase {
       s.deleteBoolByKeys(ProtoUtilV1.NS_MEMBERS, msg.sender);
       emit MemberRemoved(msg.sender);
     }
+
+    require(args.reportingBurnRate + args.governanceReporterCommission <= ProtoUtilV1.MULTIPLIER, "Invalid gov burn/commission rate");
 
     s.setAddressByKey(ProtoUtilV1.CNS_BURNER, args.burner);
 
@@ -86,7 +86,7 @@ contract Protocol is IProtocol, ProtoBase {
    * @custom:warning Warning:
    *
    * This feature is only accessible to an upgrade agent.
-   * Since adding member to the protocol is a highy risky activity,
+   * Since adding member to the protocol is a highly risky activity,
    * the role `Upgrade Agent` is considered to be one of the most `Critical` roles.
    *
    * @custom:suppress-address-trust-issue The address `member` can be trusted because this can only come from upgrade agents.
@@ -152,7 +152,7 @@ contract Protocol is IProtocol, ProtoBase {
    * @custom:warning Warning:
    *
    * This feature is only accessible to an upgrade agent.
-   * Since adding member to the protocol is a highy risky activity,
+   * Since adding member to the protocol is a highly risky activity,
    * the role `Upgrade Agent` is considered to be one of the most `Critical` roles.
    *
    * Using Tenderly War Rooms/Web3 Actions or OZ Defender, the protocol needs to be paused
@@ -201,13 +201,13 @@ contract Protocol is IProtocol, ProtoBase {
    * @dev Upgrades a contract at the given namespace and key.
    *
    * The previous contract's protocol membership is revoked and
-   * the current immediately starts assuming responsbility of
+   * the current immediately starts assuming responsibility of
    * whatever the contract needs to do at the supplied namespace and key.
    *
    * @custom:warning Warning:
    *
    * This feature is only accessible to an upgrade agent.
-   * Since adding member to the protocol is a highy risky activity,
+   * Since adding member to the protocol is a highly risky activity,
    * the role `Upgrade Agent` is considered to be one of the most `Critical` roles.
    *
    * Using Tenderly War Rooms/Web3 Actions or OZ Defender, the protocol needs to be paused
@@ -237,6 +237,28 @@ contract Protocol is IProtocol, ProtoBase {
   }
 
   /**
+   * @dev Grants roles to the protocol.
+   *
+   * Individual Neptune Mutual protocol contracts inherit roles
+   * defined to this contract. Meaning, the `AccessControl` logic
+   * here is used everywhere else.
+   *
+   * @custom:warning Warning:
+   * @custom:suppress-acl Can only be called by a role admin of the specified role(s)
+   *
+   */
+  function grantRoles(AccountWithRoles[] calldata detail) external override nonReentrant whenNotPaused {
+    // @suppress-zero-value-check Checked
+    require(detail.length > 0, "Invalid args");
+
+    for (uint256 i = 0; i < detail.length; i++) {
+      for (uint256 j = 0; j < detail[i].roles.length; j++) {
+        super.grantRole(detail[i].roles[j], detail[i].account);
+      }
+    }
+  }
+
+  /**
    * @dev Grants `role` to `account`.
    *
    * If `account` had not been already granted `role`, emits a {RoleGranted}
@@ -245,36 +267,43 @@ contract Protocol is IProtocol, ProtoBase {
    * Requirements:
    *
    * - the caller must have ``role``'s admin role.
+   * @custom:suppress-acl Check the ACL of the base function
    */
   function grantRole(bytes32 role, address account) public override(AccessControl, IAccessControl) whenNotPaused {
     super.grantRole(role, account);
   }
 
   /**
-   * @dev Grants roles to the protocol.
+   * @dev Revokes `role` from `account`.
    *
-   * Individual Neptune Mutual protocol contracts inherit roles
-   * defined to this contract. Meaning, the `AccessControl` logic
-   * here is used everywhere else.
+   * If `account` had been granted `role`, emits a {RoleRevoked} event.
    *
-   * @custom:warning Warning:
+   * Requirements:
    *
-   * This feature is only accessible to an admin. Adding any kind of role to the protocol is immensely risky.
-   *
-   * Using Tenderly War Rooms/Web3 Actions or OZ Defender, the protocol needs to be paused
-   * when this function is invoked.
-   *
+   * - the caller must have ``role``'s admin role.
+   * @custom:suppress-acl Check the ACL of the base function
    */
-  function grantRoles(AccountWithRoles[] calldata detail) external override nonReentrant whenNotPaused {
-    // @suppress-zero-value-check Checked
-    require(detail.length > 0, "Invalid args");
-    AccessControlLibV1.mustBeAdmin(s);
+  function revokeRole(bytes32 role, address account) public override(AccessControl, IAccessControl) whenNotPaused {
+    super.revokeRole(role, account);
+  }
 
-    for (uint256 i = 0; i < detail.length; i++) {
-      for (uint256 j = 0; j < detail[i].roles.length; j++) {
-        _grantRole(detail[i].roles[j], detail[i].account);
-      }
-    }
+  /**
+   * @dev Revokes `role` from the calling account.
+   *
+   * Roles are often managed via {grantRole} and {revokeRole}: this function's
+   * purpose is to provide a mechanism for accounts to lose their privileges
+   * if they are compromised (such as when a trusted device is misplaced).
+   *
+   * If the calling account had been revoked `role`, emits a {RoleRevoked}
+   * event.
+   *
+   * Requirements:
+   *
+   * - the caller must be `account`.
+   * @custom:suppress-acl Check the ACL of the base function
+   */
+  function renounceRole(bytes32 role, address account) public override(AccessControl, IAccessControl) whenNotPaused {
+    super.renounceRole(role, account);
   }
 
   /**

--- a/contracts/core/claims/Processor.sol
+++ b/contracts/core/claims/Processor.sol
@@ -1,16 +1,12 @@
 // Neptune Mutual Protocol (https://neptunemutual.com)
 // SPDX-License-Identifier: BUSL-1.1
+// solhint-disable function-max-lines
 pragma solidity ^0.8.0;
 import "../Recoverable.sol";
 import "../../interfaces/IClaimsProcessor.sol";
 import "../../interfaces/ICxToken.sol";
 import "../../interfaces/IVault.sol";
-import "../../libraries/ProtoUtilV1.sol";
-import "../../libraries/RegistryLibV1.sol";
-import "../../libraries/ValidationLibV1.sol";
 import "../../libraries/NTransferUtilV2.sol";
-import "../../libraries/StoreKeyUtil.sol";
-import "../../libraries/RoutineInvokerLibV1.sol";
 
 /**
  * @title Claims Processor Contract
@@ -37,7 +33,6 @@ contract Processor is IClaimsProcessor, Recoverable {
   using RegistryLibV1 for IStore;
   using StoreKeyUtil for IStore;
   using ValidationLibV1 for IStore;
-  using ValidationLibV1 for bytes32;
 
   /**
    * @dev Constructs this contract

--- a/contracts/core/cxToken/cxToken.sol
+++ b/contracts/core/cxToken/cxToken.sol
@@ -105,7 +105,7 @@ contract cxToken is ICxToken, Recoverable, ERC20 {
     uint256 resolutionEOD = PolicyHelperV1.getEODInternal(s.getResolutionTimestampInternal(COVER_KEY, PRODUCT_KEY));
     uint256 totalDays = (resolutionEOD - incidentDate) / 1 days;
 
-    for (uint256 i = 0; i < totalDays; i++) {
+    for (uint256 i = 0; i <= totalDays; i++) {
       uint256 date = PolicyHelperV1.getEODInternal(incidentDate + (i * 1 days));
       exclusion += coverageStartsFrom[account][date];
     }
@@ -155,7 +155,7 @@ contract cxToken is ICxToken, Recoverable, ERC20 {
     s.senderMustBePolicyContract();
     s.mustBeSupportedProductOrEmpty(coverKey, productKey);
 
-    uint256 effectiveFrom = PolicyHelperV1.getEODInternal(block.timestamp) + s.getCoverageLagInternal(coverKey); // solhint-disable-line
+    uint256 effectiveFrom = PolicyHelperV1.getEODInternal(block.timestamp + s.getCoverageLagInternal(coverKey)); // solhint-disable-line
     coverageStartsFrom[to][effectiveFrom] += amount;
 
     super._mint(to, amount);

--- a/contracts/core/cxToken/cxTokenFactory.sol
+++ b/contracts/core/cxToken/cxTokenFactory.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.0;
 import "../../interfaces/IVault.sol";
 import "../../interfaces/ICxTokenFactory.sol";
 import "../../libraries/cxTokenFactoryLibV1.sol";
-import "../../libraries/ValidationLibV1.sol";
 import "../Recoverable.sol";
 
 /**
@@ -16,10 +15,8 @@ import "../Recoverable.sol";
 // slither-disable-next-line naming-convention
 contract cxTokenFactory is ICxTokenFactory, Recoverable {
   // solhint-disable-previous-line
-  using ProtoUtilV1 for bytes;
-  using ProtoUtilV1 for IStore;
-  using ValidationLibV1 for IStore;
   using StoreKeyUtil for IStore;
+  using ValidationLibV1 for IStore;
 
   /**
    * @dev Constructs this contract

--- a/contracts/core/delegates/VaultDelegate.sol
+++ b/contracts/core/delegates/VaultDelegate.sol
@@ -26,9 +26,5 @@ import "./VaultDelegateWithFlashLoan.sol";
  *
  */
 contract VaultDelegate is VaultDelegateWithFlashLoan {
-  using ProtoUtilV1 for IStore;
-  using ValidationLibV1 for IStore;
-  using VaultLibV1 for IStore;
-
   constructor(IStore store) VaultDelegateBase(store) {} // solhint-disable-line
 }

--- a/contracts/core/delegates/VaultDelegateBase.sol
+++ b/contracts/core/delegates/VaultDelegateBase.sol
@@ -3,14 +3,9 @@
 pragma solidity ^0.8.0;
 
 import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
-import "../Recoverable.sol";
 import "../../interfaces/IVaultDelegate.sol";
-import "../../libraries/ProtoUtilV1.sol";
-import "../../libraries/CoverUtilV1.sol";
 import "../../libraries/VaultLibV1.sol";
-import "../../libraries/ValidationLibV1.sol";
-import "../../libraries/StrategyLibV1.sol";
-import "../../libraries/NTransferUtilV2.sol";
+import "../Recoverable.sol";
 
 /**
  * Important: This contract is not intended to be accessed
@@ -24,15 +19,11 @@ import "../../libraries/NTransferUtilV2.sol";
  *
  */
 abstract contract VaultDelegateBase is IVaultDelegate, Recoverable {
-  using ProtoUtilV1 for bytes;
   using ProtoUtilV1 for IStore;
-  using VaultLibV1 for IStore;
-  using ValidationLibV1 for IStore;
   using RoutineInvokerLibV1 for IStore;
-  using StoreKeyUtil for IStore;
   using StrategyLibV1 for IStore;
-  using CoverUtilV1 for IStore;
-  using NTransferUtilV2 for IERC20;
+  using ValidationLibV1 for IStore;
+  using VaultLibV1 for IStore;
 
   /**
    * @dev Constructs this contract

--- a/contracts/core/delegates/VaultDelegateWithFlashLoan.sol
+++ b/contracts/core/delegates/VaultDelegateWithFlashLoan.sol
@@ -15,10 +15,10 @@ import "./VaultDelegateBase.sol";
  */
 abstract contract VaultDelegateWithFlashLoan is VaultDelegateBase {
   using ProtoUtilV1 for IStore;
+  using RoutineInvokerLibV1 for IStore;
   using StoreKeyUtil for IStore;
   using ValidationLibV1 for IStore;
   using VaultLibV1 for IStore;
-  using RoutineInvokerLibV1 for IStore;
 
   /**
    * @dev The fee to be charged for a given loan.

--- a/contracts/core/governance/Governance.sol
+++ b/contracts/core/governance/Governance.sol
@@ -39,12 +39,6 @@ import "../../interfaces/IGovernance.sol";
  *
  */
 contract Governance is IGovernance, Reporter {
-  using GovernanceUtilV1 for IStore;
-  using CoverUtilV1 for IStore;
-  using StoreKeyUtil for IStore;
-  using ValidationLibV1 for IStore;
-  using ValidationLibV1 for bytes32;
-
   constructor(IStore store) Recoverable(store) {} // solhint-disable-line
 
   /**

--- a/contracts/core/governance/Reporter.sol
+++ b/contracts/core/governance/Reporter.sol
@@ -163,7 +163,7 @@ abstract contract Reporter is IReporter, Witness {
    *
    * If you get resolution in your favor, you will receive these rewards:
    *
-   * - A 10% commission on all reward received by valid camp voters (check `Unstakeable.unstakeWithClaim`) in NPM tokens.
+   * - A 10% commission on all reward received by valid camp voters (check `Unstakable.unstakeWithClaim`) in NPM tokens.
    * - Your proportional share of the 60% pool of the invalid camp.
    *
    * @custom:warning **Warning:**
@@ -278,6 +278,8 @@ abstract contract Reporter is IReporter, Witness {
     s.mustNotBePaused();
     AccessControlLibV1.mustBeCoverManager(s);
 
+    require(s.getGovernanceReporterCommissionInternal() + value <= ProtoUtilV1.MULTIPLIER, "Rate too high");
+
     uint256 previous = s.getUintByKey(ProtoUtilV1.NS_GOVERNANCE_REPORTING_BURN_RATE);
     s.setUintByKey(ProtoUtilV1.NS_GOVERNANCE_REPORTING_BURN_RATE, value);
 
@@ -297,9 +299,12 @@ abstract contract Reporter is IReporter, Witness {
    *
    */
   function setReporterCommission(uint256 value) external override nonReentrant {
+    require(value > 0, "Please specify value");
+
     s.mustNotBePaused();
     AccessControlLibV1.mustBeCoverManager(s);
-    require(value > 0, "Please specify value");
+
+    require(s.getReportingBurnRateInternal() + value <= ProtoUtilV1.MULTIPLIER, "Rate too high");
 
     uint256 previous = s.getUintByKey(ProtoUtilV1.NS_GOVERNANCE_REPORTER_COMMISSION);
     s.setUintByKey(ProtoUtilV1.NS_GOVERNANCE_REPORTER_COMMISSION, value);
@@ -341,7 +346,7 @@ abstract contract Reporter is IReporter, Witness {
   }
 
   /**
-   * @dev Retuns the resolution date of a given cover
+   * @dev Returns the resolution date of a given cover
    *
    * Warning: this function does not validate the input arguments.
    *
@@ -362,7 +367,7 @@ abstract contract Reporter is IReporter, Witness {
    * @param coverKey Enter the cover key you want to get attestation of
    * @param productKey Enter the product key you want to get attestation of
    * @param who Enter the account you want to get attestation of
-   * @param who Enter the specified cover's indicent date for which attestation will be returned
+   * @param who Enter the specified cover's incident date for which attestation will be returned
    *
    */
   function getAttestation(
@@ -383,7 +388,7 @@ abstract contract Reporter is IReporter, Witness {
    * @param coverKey Enter the cover key you want to get refutation of
    * @param productKey Enter the product key you want to get refutation of
    * @param who Enter the account you want to get refutation of
-   * @param who Enter the specified cover's indicent date for which refutation will be returned
+   * @param who Enter the specified cover's incident date for which refutation will be returned
    *
    */
   function getRefutation(

--- a/contracts/core/governance/Witness.sol
+++ b/contracts/core/governance/Witness.sol
@@ -2,15 +2,9 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.0;
 import "../Recoverable.sol";
-import "../../libraries/ProtoUtilV1.sol";
-import "../../libraries/StoreKeyUtil.sol";
-import "../../libraries/CoverUtilV1.sol";
 import "../../interfaces/IWitness.sol";
-import "../../libraries/NTransferUtilV2.sol";
-import "../../libraries/GovernanceUtilV1.sol";
-import "../../libraries/ValidationLibV1.sol";
-import "../../libraries/RegistryLibV1.sol";
 import "../../interfaces/IVault.sol";
+import "../../libraries/NTransferUtilV2.sol";
 
 /**
  * @title Witness Contract
@@ -55,13 +49,11 @@ import "../../interfaces/IVault.sol";
  *
  */
 abstract contract Witness is Recoverable, IWitness {
-  using ProtoUtilV1 for bytes;
   using ProtoUtilV1 for IStore;
   using RegistryLibV1 for IStore;
   using CoverUtilV1 for IStore;
   using GovernanceUtilV1 for IStore;
   using ValidationLibV1 for IStore;
-  using StoreKeyUtil for IStore;
   using NTransferUtilV2 for IERC20;
 
   /**

--- a/contracts/core/governance/resolution/Finalization.sol
+++ b/contracts/core/governance/resolution/Finalization.sol
@@ -3,9 +3,6 @@
 pragma solidity ^0.8.0;
 import "../../Recoverable.sol";
 import "../../../interfaces/IFinalization.sol";
-import "../../../libraries/GovernanceUtilV1.sol";
-import "../../../libraries/ValidationLibV1.sol";
-import "../../../libraries/RoutineInvokerLibV1.sol";
 
 /**
  * @title Finalization Contract
@@ -18,12 +15,9 @@ import "../../../libraries/RoutineInvokerLibV1.sol";
  */
 abstract contract Finalization is Recoverable, IFinalization {
   using GovernanceUtilV1 for IStore;
-  using CoverUtilV1 for IStore;
   using StoreKeyUtil for IStore;
   using ValidationLibV1 for IStore;
   using RoutineInvokerLibV1 for IStore;
-  using ProtoUtilV1 for IStore;
-  using ValidationLibV1 for bytes32;
 
   /**
    * @dev Finalizes a cover pool or a product contract.

--- a/contracts/core/governance/resolution/Resolution.sol
+++ b/contracts/core/governance/resolution/Resolution.sol
@@ -5,20 +5,16 @@ import "./Unstakable.sol";
 import "../../../interfaces/IResolution.sol";
 
 /**
+ *
  * @title Resolution Contract
  * @dev This contract enables governance agents or admins to resolve
  * actively-reporting cover products. Once a resolution occurs, the
  * NPM token holders who voted for the valid camp can unstake
- * their staking during the claim period with additional rewards.
+ * their stakes after resolution and before finalization
+ * with additional rewards.
+ *
  */
 contract Resolution is IResolution, Unstakable {
-  using GovernanceUtilV1 for IStore;
-  using ProtoUtilV1 for IStore;
-  using CoverUtilV1 for IStore;
-  using StoreKeyUtil for IStore;
-  using ValidationLibV1 for IStore;
-  using ValidationLibV1 for bytes32;
-
   constructor(IStore store) Recoverable(store) {} // solhint-disable-line
 
   /**

--- a/contracts/core/governance/resolution/Resolvable.sol
+++ b/contracts/core/governance/resolution/Resolvable.sol
@@ -4,7 +4,6 @@
 pragma solidity ^0.8.0;
 import "./Finalization.sol";
 import "../../../interfaces/IResolvable.sol";
-import "../../../libraries/NTransferUtilV2.sol";
 
 /**
  * @title Resolvable Contract
@@ -13,16 +12,14 @@ import "../../../libraries/NTransferUtilV2.sol";
  * can perform emergency resolution to defend against governance attacks.
  */
 abstract contract Resolvable is Finalization, IResolvable {
-  using GovernanceUtilV1 for IStore;
-  using ProtoUtilV1 for IStore;
   using CoverUtilV1 for IStore;
-  using StoreKeyUtil for IStore;
+  using GovernanceUtilV1 for IStore;
   using RoutineInvokerLibV1 for IStore;
+  using StoreKeyUtil for IStore;
   using ValidationLibV1 for IStore;
-  using ValidationLibV1 for bytes32;
 
   /**
-   * @dev Marks as a cover as "resolved" after the reporting period.
+   * @dev Marks a cover as "resolved" after the reporting period.
    * A resolution has a (configurable) 24-hour cooldown period
    * that enables governance admins to revese decision in case of
    * attack or mistake.

--- a/contracts/core/governance/resolution/Unstakable.sol
+++ b/contracts/core/governance/resolution/Unstakable.sol
@@ -4,8 +4,6 @@ pragma solidity ^0.8.0;
 import "./Resolvable.sol";
 import "../../../interfaces/IResolution.sol";
 import "../../../interfaces/IUnstakable.sol";
-import "../../../libraries/GovernanceUtilV1.sol";
-import "../../../libraries/ValidationLibV1.sol";
 import "../../../libraries/NTransferUtilV2.sol";
 
 /**
@@ -15,22 +13,19 @@ import "../../../libraries/NTransferUtilV2.sol";
  */
 abstract contract Unstakable is Resolvable, IUnstakable {
   using GovernanceUtilV1 for IStore;
-  using ProtoUtilV1 for IStore;
-  using CoverUtilV1 for IStore;
-  using StoreKeyUtil for IStore;
-  using ValidationLibV1 for IStore;
-  using RoutineInvokerLibV1 for IStore;
-  using ValidationLibV1 for bytes32;
   using NTransferUtilV2 for IERC20;
+  using ProtoUtilV1 for IStore;
+  using RoutineInvokerLibV1 for IStore;
+  using ValidationLibV1 for IStore;
 
   /**
-   * @dev Reporters on the valid camp can unstake their tokens even after the claim period is over.
+   * @dev Reporters on the valid camp can unstake their tokens even after finalization.
    * Unlike `unstakeWithClaim`, stakers can unstake but do not receive any reward if they choose to
    * use this function.
    *
    * @custom:warning Warning:
    *
-   * You should instead use `unstakeWithClaim` throughout the claim period.
+   * You should instead use `unstakeWithClaim` after resolution and before finalization.
    *
    * @custom:suppress-acl This is a publicly accessible feature
    * @custom:suppress-pausable

--- a/contracts/core/lifecycle/Cover.sol
+++ b/contracts/core/lifecycle/Cover.sol
@@ -5,7 +5,6 @@ import "./CoverBase.sol";
 import "../../interfaces/ICoverStake.sol";
 import "../../interfaces/ICoverStake.sol";
 import "../../interfaces/IVault.sol";
-import "../liquidity/Vault.sol";
 
 /**
  * @title Cover Contract
@@ -13,13 +12,11 @@ import "../liquidity/Vault.sol";
  *
  */
 contract Cover is CoverBase {
-  using AccessControlLibV1 for IStore;
   using CoverLibV1 for IStore;
   using CoverUtilV1 for IStore;
-  using StoreKeyUtil for IStore;
-  using ProtoUtilV1 for IStore;
-  using ValidationLibV1 for IStore;
   using RoutineInvokerLibV1 for IStore;
+  using StoreKeyUtil for IStore;
+  using ValidationLibV1 for IStore;
 
   /**
    * @dev Constructs this contract
@@ -189,7 +186,7 @@ contract Cover is CoverBase {
    * When a cover requires whitelist, you must add accounts
    * to the cover user whitelist before they are able to purchase policies.
    *
-   * @custom:suppress-acl This function is only accessilbe to the cover owner or admin
+   * @custom:suppress-acl This function is only accessible to the cover owner or admin
    *
    * @param coverKey Enter cover key
    * @param productKey Enter product key

--- a/contracts/core/lifecycle/CoverBase.sol
+++ b/contracts/core/lifecycle/CoverBase.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.0;
 import "../../interfaces/IStore.sol";
 import "../../interfaces/ICover.sol";
 import "../../libraries/CoverLibV1.sol";
-import "../../libraries/StoreKeyUtil.sol";
 import "../Recoverable.sol";
 
 /**

--- a/contracts/core/lifecycle/CoverReassurance.sol
+++ b/contracts/core/lifecycle/CoverReassurance.sol
@@ -3,12 +3,7 @@
 pragma solidity ^0.8.0;
 import "../../interfaces/IStore.sol";
 import "../../interfaces/ICoverReassurance.sol";
-import "../../libraries/ProtoUtilV1.sol";
-import "../../libraries/CoverUtilV1.sol";
-import "../../libraries/ValidationLibV1.sol";
-import "../../libraries/StoreKeyUtil.sol";
 import "../../libraries/NTransferUtilV2.sol";
-import "../../libraries/GovernanceUtilV1.sol";
 import "../Recoverable.sol";
 
 /**
@@ -25,15 +20,14 @@ import "../Recoverable.sol";
  *
  */
 contract CoverReassurance is ICoverReassurance, Recoverable {
-  using ProtoUtilV1 for bytes;
-  using ProtoUtilV1 for IStore;
-  using StoreKeyUtil for IStore;
-  using NTransferUtilV2 for IERC20;
   using CoverUtilV1 for IStore;
-  using ValidationLibV1 for IStore;
+  using GovernanceUtilV1 for IStore;
+  using NTransferUtilV2 for IERC20;
+  using ProtoUtilV1 for IStore;
   using RegistryLibV1 for IStore;
   using RoutineInvokerLibV1 for IStore;
-  using GovernanceUtilV1 for IStore;
+  using StoreKeyUtil for IStore;
+  using ValidationLibV1 for IStore;
 
   constructor(IStore store) Recoverable(store) {} // solhint-disable-line
 

--- a/contracts/core/lifecycle/CoverStake.sol
+++ b/contracts/core/lifecycle/CoverStake.sol
@@ -3,10 +3,6 @@
 pragma solidity ^0.8.0;
 
 import "../../interfaces/ICoverStake.sol";
-import "../../libraries/ProtoUtilV1.sol";
-import "../../libraries/CoverUtilV1.sol";
-import "../../libraries/StoreKeyUtil.sol";
-import "../../libraries/ValidationLibV1.sol";
 import "../../libraries/NTransferUtilV2.sol";
 import "../Recoverable.sol";
 
@@ -25,7 +21,6 @@ import "../Recoverable.sol";
  *
  */
 contract CoverStake is ICoverStake, Recoverable {
-  using ProtoUtilV1 for bytes;
   using ProtoUtilV1 for IStore;
   using StoreKeyUtil for IStore;
   using CoverUtilV1 for IStore;

--- a/contracts/core/liquidity/LiquidityEngine.sol
+++ b/contracts/core/liquidity/LiquidityEngine.sol
@@ -3,11 +3,9 @@
 pragma solidity ^0.8.0;
 // import "../../interfaces/IVault.sol";
 import "../Recoverable.sol";
-import "../../libraries/NTransferUtilV2.sol";
-import "../../libraries/StoreKeyUtil.sol";
-import "../../libraries/StrategyLibV1.sol";
 import "../../interfaces/ILendingStrategy.sol";
 import "../../interfaces/ILiquidityEngine.sol";
+import "../../libraries/NTransferUtilV2.sol";
 
 /**
  * @title Liquidity Engine contract

--- a/contracts/core/liquidity/Vault.sol
+++ b/contracts/core/liquidity/Vault.sol
@@ -57,7 +57,7 @@ contract Vault is WithFlashLoan {
   using RegistryLibV1 for IStore;
 
   /**
-   * @dev Contructs this contract
+   * @dev Constructs this contract
    *
    * @param store Provide store instance
    * @param coverKey Provide a cover key that doesn't have a vault deployed

--- a/contracts/core/liquidity/Vault.sol
+++ b/contracts/core/liquidity/Vault.sol
@@ -83,7 +83,7 @@ contract Vault is WithFlashLoan {
    *
    */
   function getInfo(address you) external view override returns (VaultInfoType memory) {
-    return delgate().getInfoImplementation(key, you);
+    return delegate().getInfoImplementation(key, you);
   }
 
   /**

--- a/contracts/core/liquidity/VaultBase.sol
+++ b/contracts/core/liquidity/VaultBase.sol
@@ -43,8 +43,7 @@ abstract contract VaultBase is ERC20, Recoverable, IVault {
   /**
    * @dev Returns the delegate contract instance
    */
-  function delgate() public view returns (IVaultDelegate) {
-    address delegate = s.getVaultDelegate();
-    return IVaultDelegate(delegate);
+  function delegate() public view returns (IVaultDelegate) {
+    return IVaultDelegate(s.getVaultDelegate());
   }
 }

--- a/contracts/core/liquidity/VaultBase.sol
+++ b/contracts/core/liquidity/VaultBase.sol
@@ -20,7 +20,7 @@ abstract contract VaultBase is ERC20, Recoverable, IVault {
   address public override sc;
 
   /**
-   * @dev Contructs this contract
+   * @dev Constructs this contract
    *
    * @param store Provide store instance
    * @param coverKey Provide a cover key that doesn't have a vault deployed

--- a/contracts/core/liquidity/VaultFactory.sol
+++ b/contracts/core/liquidity/VaultFactory.sol
@@ -4,7 +4,6 @@ pragma solidity ^0.8.0;
 import "../../interfaces/IVault.sol";
 import "../../interfaces/IVaultFactory.sol";
 import "../../libraries/VaultFactoryLibV1.sol";
-import "../../libraries/ValidationLibV1.sol";
 import "../Recoverable.sol";
 
 /**
@@ -15,9 +14,7 @@ import "../Recoverable.sol";
  *
  */
 contract VaultFactory is IVaultFactory, Recoverable {
-  using ProtoUtilV1 for bytes;
   using ProtoUtilV1 for IStore;
-  using StoreKeyUtil for IStore;
   using ValidationLibV1 for IStore;
 
   /**
@@ -29,7 +26,7 @@ contract VaultFactory is IVaultFactory, Recoverable {
   /**
    * @dev Deploys a new instance of Vault
    *
-   * @custom:suppress-acl This function is only accessilbe to the cover contract
+   * @custom:suppress-acl This function is only accessible to the cover contract
    *
    * @param coverKey Enter the cover key related to this Vault instance
    */

--- a/contracts/core/liquidity/VaultLiquidity.sol
+++ b/contracts/core/liquidity/VaultLiquidity.sol
@@ -170,7 +170,7 @@ abstract contract VaultLiquidity is VaultBase {
   }
 
   /**
-   * @dev Accrues interests from external straties
+   * @dev Accrues interests from external strategies
    *
    * @custom:suppress-acl This is a publicly accessible feature
    * @custom:suppress-pausable Validated in `accrueInterestImplementation`

--- a/contracts/core/liquidity/VaultLiquidity.sol
+++ b/contracts/core/liquidity/VaultLiquidity.sol
@@ -28,7 +28,7 @@ abstract contract VaultLiquidity is VaultBase {
     /******************************************************************************************
       PRE
      ******************************************************************************************/
-    address stablecoin = delgate().preTransferGovernance(msg.sender, coverKey, to, amount);
+    address stablecoin = delegate().preTransferGovernance(msg.sender, coverKey, to, amount);
 
     /******************************************************************************************
       BODY
@@ -39,7 +39,7 @@ abstract contract VaultLiquidity is VaultBase {
     /******************************************************************************************
       POST
      ******************************************************************************************/
-    delgate().postTransferGovernance(msg.sender, coverKey, to, amount);
+    delegate().postTransferGovernance(msg.sender, coverKey, to, amount);
     emit GovernanceTransfer(to, amount);
   }
 
@@ -60,7 +60,7 @@ abstract contract VaultLiquidity is VaultBase {
       PRE
      ******************************************************************************************/
 
-    (uint256 podsToMint, uint256 previousNpmStake) = delgate().preAddLiquidity(msg.sender, args.coverKey, args.amount, args.npmStakeToAdd);
+    (uint256 podsToMint, uint256 previousNpmStake) = delegate().preAddLiquidity(msg.sender, args.coverKey, args.amount, args.npmStakeToAdd);
 
     require(podsToMint > 0, "Can't determine PODs");
 
@@ -80,7 +80,7 @@ abstract contract VaultLiquidity is VaultBase {
       POST
      ******************************************************************************************/
 
-    delgate().postAddLiquidity(msg.sender, args.coverKey, args.amount, args.npmStakeToAdd);
+    delegate().postAddLiquidity(msg.sender, args.coverKey, args.amount, args.npmStakeToAdd);
 
     emit PodsIssued(msg.sender, podsToMint, args.amount, args.referralCode);
 
@@ -114,7 +114,7 @@ abstract contract VaultLiquidity is VaultBase {
     /******************************************************************************************
       PRE
      ******************************************************************************************/
-    (address stablecoin, uint256 stablecoinToRelease) = delgate().preRemoveLiquidity(msg.sender, coverKey, podsToRedeem, npmStakeToRemove, exit);
+    (address stablecoin, uint256 stablecoinToRelease) = delegate().preRemoveLiquidity(msg.sender, coverKey, podsToRedeem, npmStakeToRemove, exit);
 
     /******************************************************************************************
       BODY
@@ -134,7 +134,7 @@ abstract contract VaultLiquidity is VaultBase {
     /******************************************************************************************
       POST
      ******************************************************************************************/
-    delgate().postRemoveLiquidity(msg.sender, coverKey, podsToRedeem, npmStakeToRemove, exit);
+    delegate().postRemoveLiquidity(msg.sender, coverKey, podsToRedeem, npmStakeToRemove, exit);
 
     emit PodsRedeemed(msg.sender, podsToRedeem, stablecoinToRelease);
 
@@ -151,14 +151,14 @@ abstract contract VaultLiquidity is VaultBase {
    * @dev Calculates the amount of PODS to mint for the given amount of liquidity to transfer
    */
   function calculatePods(uint256 forStablecoinUnits) external view override returns (uint256) {
-    return delgate().calculatePodsImplementation(key, forStablecoinUnits);
+    return delegate().calculatePodsImplementation(key, forStablecoinUnits);
   }
 
   /**
    * @dev Calculates the amount of stablecoins to withdraw for the given amount of PODs to redeem
    */
   function calculateLiquidity(uint256 podsToBurn) external view override returns (uint256) {
-    return delgate().calculateLiquidityImplementation(key, podsToBurn);
+    return delegate().calculateLiquidityImplementation(key, podsToBurn);
   }
 
   /**
@@ -166,7 +166,7 @@ abstract contract VaultLiquidity is VaultBase {
    * This also includes amounts lent out in lending strategies
    */
   function getStablecoinBalanceOf() external view override returns (uint256) {
-    return delgate().getStablecoinBalanceOfImplementation(key);
+    return delegate().getStablecoinBalanceOfImplementation(key);
   }
 
   /**
@@ -177,7 +177,7 @@ abstract contract VaultLiquidity is VaultBase {
    *
    */
   function accrueInterest() external override nonReentrant {
-    delgate().accrueInterestImplementation(msg.sender, key);
+    delegate().accrueInterestImplementation(msg.sender, key);
     emit InterestAccrued(key);
   }
 }

--- a/contracts/core/liquidity/VaultStrategy.sol
+++ b/contracts/core/liquidity/VaultStrategy.sol
@@ -40,7 +40,7 @@ abstract contract VaultStrategy is VaultLiquidity {
     /******************************************************************************************
       PRE
      ******************************************************************************************/
-    delgate().preTransferToStrategy(msg.sender, token, coverKey, strategyName, amount);
+    delegate().preTransferToStrategy(msg.sender, token, coverKey, strategyName, amount);
 
     /******************************************************************************************
       BODY
@@ -51,7 +51,7 @@ abstract contract VaultStrategy is VaultLiquidity {
     /******************************************************************************************
       POST
      ******************************************************************************************/
-    delgate().postTransferToStrategy(msg.sender, token, coverKey, strategyName, amount);
+    delegate().postTransferToStrategy(msg.sender, token, coverKey, strategyName, amount);
 
     emit StrategyTransfer(address(token), msg.sender, strategyName, amount);
     _transferToStrategyEntry = 0;
@@ -81,7 +81,7 @@ abstract contract VaultStrategy is VaultLiquidity {
     /******************************************************************************************
       PRE
      ******************************************************************************************/
-    delgate().preReceiveFromStrategy(msg.sender, token, coverKey, strategyName, amount);
+    delegate().preReceiveFromStrategy(msg.sender, token, coverKey, strategyName, amount);
 
     /******************************************************************************************
       BODY
@@ -92,7 +92,7 @@ abstract contract VaultStrategy is VaultLiquidity {
     /******************************************************************************************
       POST
      ******************************************************************************************/
-    (uint256 income, uint256 loss) = delgate().postReceiveFromStrategy(msg.sender, token, coverKey, strategyName, amount);
+    (uint256 income, uint256 loss) = delegate().postReceiveFromStrategy(msg.sender, token, coverKey, strategyName, amount);
 
     emit StrategyReceipt(address(token), msg.sender, strategyName, amount, income, loss);
     _receiveFromStrategyEntry = 0;

--- a/contracts/core/liquidity/WithFlashLoan.sol
+++ b/contracts/core/liquidity/WithFlashLoan.sol
@@ -65,7 +65,7 @@ abstract contract WithFlashLoan is VaultStrategy, IERC3156FlashLender {
   }
 
   /**
-   * @dev Gets the fee required to borrow the spefied token and given amount of the loan.
+   * @dev Gets the fee required to borrow the specified token and given amount of the loan.
    */
   function flashFee(address token, uint256 amount) external view override returns (uint256) {
     return delgate().getFlashFee(msg.sender, key, token, amount);

--- a/contracts/core/liquidity/WithFlashLoan.sol
+++ b/contracts/core/liquidity/WithFlashLoan.sol
@@ -35,7 +35,7 @@ abstract contract WithFlashLoan is VaultStrategy, IERC3156FlashLender {
     /******************************************************************************************
       PRE
      ******************************************************************************************/
-    (IERC20 stablecoin, uint256 fee, uint256 protocolFee) = delgate().preFlashLoan(msg.sender, key, receiver, token, amount, data);
+    (IERC20 stablecoin, uint256 fee, uint256 protocolFee) = delegate().preFlashLoan(msg.sender, key, receiver, token, amount, data);
 
     /******************************************************************************************
       BODY
@@ -57,7 +57,7 @@ abstract contract WithFlashLoan is VaultStrategy, IERC3156FlashLender {
       POST
      ******************************************************************************************/
 
-    delgate().postFlashLoan(msg.sender, key, receiver, token, amount, data);
+    delegate().postFlashLoan(msg.sender, key, receiver, token, amount, data);
 
     emit FlashLoanBorrowed(address(this), address(receiver), token, amount, fee);
 
@@ -68,13 +68,13 @@ abstract contract WithFlashLoan is VaultStrategy, IERC3156FlashLender {
    * @dev Gets the fee required to borrow the specified token and given amount of the loan.
    */
   function flashFee(address token, uint256 amount) external view override returns (uint256) {
-    return delgate().getFlashFee(msg.sender, key, token, amount);
+    return delegate().getFlashFee(msg.sender, key, token, amount);
   }
 
   /**
    * @dev Gets maximum amount in the specified token units that can be borrowed.
    */
   function maxFlashLoan(address token) external view override returns (uint256) {
-    return delgate().getMaxFlashLoan(msg.sender, key, token);
+    return delegate().getMaxFlashLoan(msg.sender, key, token);
   }
 }

--- a/contracts/core/liquidity/strategies/AaveStrategy.sol
+++ b/contracts/core/liquidity/strategies/AaveStrategy.sol
@@ -6,16 +6,14 @@ import "openzeppelin-solidity/contracts/utils/Address.sol";
 import "../../Recoverable.sol";
 import "../../../interfaces/ILendingStrategy.sol";
 import "../../../dependencies/aave/IAaveV2LendingPoolLike.sol";
-import "../../../libraries/ProtoUtilV1.sol";
-import "../../../libraries/StoreKeyUtil.sol";
 import "../../../libraries/NTransferUtilV2.sol";
 
 contract AaveStrategy is ILendingStrategy, Recoverable {
+  using NTransferUtilV2 for IERC20;
   using ProtoUtilV1 for IStore;
   using StoreKeyUtil for IStore;
   using ValidationLibV1 for IStore;
   using RegistryLibV1 for IStore;
-  using NTransferUtilV2 for IERC20;
 
   bytes32 public constant CNAME_STRATEGY_AAVE = "Aave Strategy";
   bytes32 private constant _KEY = keccak256(abi.encodePacked("lending", "strategy", "aave", "v2"));

--- a/contracts/core/liquidity/strategies/CompoundStrategy.sol
+++ b/contracts/core/liquidity/strategies/CompoundStrategy.sol
@@ -5,16 +5,14 @@ pragma solidity ^0.8.0;
 import "../../Recoverable.sol";
 import "../../../interfaces/ILendingStrategy.sol";
 import "../../../dependencies/compound/ICompoundERC20DelegatorLike.sol";
-import "../../../libraries/ProtoUtilV1.sol";
-import "../../../libraries/StoreKeyUtil.sol";
 import "../../../libraries/NTransferUtilV2.sol";
 
 contract CompoundStrategy is ILendingStrategy, Recoverable {
+  using NTransferUtilV2 for IERC20;
   using ProtoUtilV1 for IStore;
   using StoreKeyUtil for IStore;
   using ValidationLibV1 for IStore;
   using RegistryLibV1 for IStore;
-  using NTransferUtilV2 for IERC20;
 
   mapping(bytes32 => uint256) private _counters;
   mapping(bytes32 => uint256) private _depositTotal;

--- a/contracts/core/policy/Policy.sol
+++ b/contracts/core/policy/Policy.sol
@@ -7,11 +7,7 @@ import "../../interfaces/IStore.sol";
 import "../../interfaces/ICxTokenFactory.sol";
 import "../../interfaces/ICxToken.sol";
 import "../../interfaces/IPolicy.sol";
-import "../../libraries/CoverUtilV1.sol";
-import "../../libraries/RegistryLibV1.sol";
-import "../../libraries/ProtoUtilV1.sol";
 import "../../libraries/PolicyHelperV1.sol";
-import "../../libraries/RoutineInvokerLibV1.sol";
 import "../Recoverable.sol";
 
 /**
@@ -20,13 +16,9 @@ import "../Recoverable.sol";
  */
 contract Policy is IPolicy, Recoverable {
   using PolicyHelperV1 for IStore;
-  using ProtoUtilV1 for bytes;
   using ProtoUtilV1 for IStore;
   using CoverUtilV1 for IStore;
-  using RegistryLibV1 for IStore;
-  using NTransferUtilV2 for IERC20;
   using ValidationLibV1 for IStore;
-  using RoutineInvokerLibV1 for IStore;
   using StrategyLibV1 for IStore;
 
   /**

--- a/contracts/core/policy/PolicyAdmin.sol
+++ b/contracts/core/policy/PolicyAdmin.sol
@@ -5,8 +5,6 @@ import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
 import "../../interfaces/IStore.sol";
 import "../../interfaces/IPolicyAdmin.sol";
 import "../../libraries/PolicyHelperV1.sol";
-import "../../libraries/StoreKeyUtil.sol";
-import "../../libraries/ProtoUtilV1.sol";
 import "../Recoverable.sol";
 
 /**
@@ -15,14 +13,12 @@ import "../Recoverable.sol";
  * to set the policy rate and fee info.
  */
 contract PolicyAdmin is IPolicyAdmin, Recoverable {
-  using ProtoUtilV1 for bytes;
-  using PolicyHelperV1 for IStore;
-  using ProtoUtilV1 for IStore;
-  using ValidationLibV1 for IStore;
   using CoverUtilV1 for IStore;
-  using StoreKeyUtil for IStore;
-  using NTransferUtilV2 for IERC20;
+  using GovernanceUtilV1 for IStore;
+  using PolicyHelperV1 for IStore;
   using RoutineInvokerLibV1 for IStore;
+  using StoreKeyUtil for IStore;
+  using ValidationLibV1 for IStore;
 
   /**
    * @dev Constructs this contract

--- a/contracts/libraries/AccessControlLibV1.sol
+++ b/contracts/libraries/AccessControlLibV1.sol
@@ -234,17 +234,14 @@ library AccessControlLibV1 {
    * @dev Upgrades a contract at the given namespace and key.
    *
    * The previous contract's protocol membership is revoked and
-   * the current immediately starts assuming responsbility of
+   * the current immediately starts assuming responsibility of
    * whatever the contract needs to do at the supplied namespace and key.
    *
    * @custom:warning Warning:
    *
    * This feature is only accessible to an upgrade agent.
-   * Since adding member to the protocol is a highy risky activity,
+   * Since adding member to the protocol is a highly risky activity,
    * the role `Upgrade Agent` is considered to be one of the most `Critical` roles.
-   *
-   * Using Tenderly War Rooms/Web3 Actions or OZ Defender, the protocol needs to be paused
-   * when this function is invoked.
    *
    * @custom:suppress-address-trust-issue This feature can only be accessed internally within the protocol.
    *
@@ -283,11 +280,8 @@ library AccessControlLibV1 {
    * @custom:warning Warning:
    *
    * This feature is only accessible to an upgrade agent.
-   * Since adding member to the protocol is a highy risky activity,
+   * Since adding member to the protocol is a highly risky activity,
    * the role `Upgrade Agent` is considered to be one of the most `Critical` roles.
-   *
-   * Using Tenderly War Rooms/Web3 Actions or OZ Defender, the protocol needs to be paused
-   * when this function is invoked.
    *
    * @custom:suppress-address-trust-issue This feature can only be accessed internally within the protocol.
    *

--- a/contracts/libraries/BaseLibV1.sol
+++ b/contracts/libraries/BaseLibV1.sol
@@ -4,13 +4,10 @@
 pragma solidity ^0.8.0;
 import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/utils/SafeERC20.sol";
-import "./ValidationLibV1.sol";
-import "./AccessControlLibV1.sol";
 import "../interfaces/IProtocol.sol";
 import "../interfaces/IPausable.sol";
 
 library BaseLibV1 {
-  using ValidationLibV1 for IStore;
   using SafeERC20 for IERC20;
 
   /**

--- a/contracts/libraries/BondPoolLibV1.sol
+++ b/contracts/libraries/BondPoolLibV1.sol
@@ -3,15 +3,12 @@
 /* solhint-disable ordering  */
 pragma solidity ^0.8.0;
 import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
-import "./ValidationLibV1.sol";
-import "./NTransferUtilV2.sol";
-import "./AccessControlLibV1.sol";
-import "./PriceLibV1.sol";
 import "../interfaces/IProtocol.sol";
 import "../interfaces/IPausable.sol";
+import "./NTransferUtilV2.sol";
+import "./ValidationLibV1.sol";
 
 library BondPoolLibV1 {
-  using AccessControlLibV1 for IStore;
   using NTransferUtilV2 for IERC20;
   using PriceLibV1 for IStore;
   using ProtoUtilV1 for IStore;

--- a/contracts/libraries/CoverLibV1.sol
+++ b/contracts/libraries/CoverLibV1.sol
@@ -1,27 +1,20 @@
 // Neptune Mutual Protocol (https://neptunemutual.com)
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.0;
-import "../interfaces/IStore.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
-import "./ProtoUtilV1.sol";
-import "./AccessControlLibV1.sol";
-import "./CoverUtilV1.sol";
-import "./RegistryLibV1.sol";
-import "./StoreKeyUtil.sol";
-import "./RoutineInvokerLibV1.sol";
-import "./StrategyLibV1.sol";
+import "../interfaces/IStore.sol";
 import "./NTransferUtilV2.sol";
+import "./ValidationLibV1.sol";
 
 library CoverLibV1 {
-  using CoverUtilV1 for IStore;
-  using RegistryLibV1 for IStore;
-  using StoreKeyUtil for IStore;
-  using ProtoUtilV1 for IStore;
-  using RoutineInvokerLibV1 for IStore;
   using AccessControlLibV1 for IStore;
-  using ValidationLibV1 for IStore;
-  using StrategyLibV1 for IStore;
+  using CoverUtilV1 for IStore;
   using NTransferUtilV2 for IERC20;
+  using ProtoUtilV1 for IStore;
+  using RegistryLibV1 for IStore;
+  using RoutineInvokerLibV1 for IStore;
+  using StoreKeyUtil for IStore;
+  using ValidationLibV1 for IStore;
 
   event CoverUserWhitelistUpdated(bytes32 indexed coverKey, bytes32 indexed productKey, address indexed account, bool status);
 
@@ -116,6 +109,7 @@ library CoverLibV1 {
     require(args.ceiling > args.floor, "Invalid ceiling rate");
     require(args.reassuranceRate > 0, "Invalid reassurance rate");
     require(args.leverageFactor > 0 && args.leverageFactor < 25, "Invalid leverage");
+    require(args.reportingPeriod >= s.getCoverageLagInternal(args.coverKey), "Invalid reporting period");
 
     if (args.supportsProducts == false) {
       // Standalone pools do not support any leverage

--- a/contracts/libraries/CoverUtilV1.sol
+++ b/contracts/libraries/CoverUtilV1.sol
@@ -4,22 +4,17 @@ pragma solidity ^0.8.0;
 import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
 import "../dependencies/BokkyPooBahsDateTimeLibrary.sol";
 import "../interfaces/IStore.sol";
-import "./ProtoUtilV1.sol";
-import "./AccessControlLibV1.sol";
-import "./StoreKeyUtil.sol";
-import "./RegistryLibV1.sol";
-import "./StrategyLibV1.sol";
 import "../interfaces/ICxToken.sol";
 import "../interfaces/IERC20Detailed.sol";
+import "./StrategyLibV1.sol";
 
 library CoverUtilV1 {
-  using RegistryLibV1 for IStore;
   using ProtoUtilV1 for IStore;
   using StoreKeyUtil for IStore;
-  using AccessControlLibV1 for IStore;
   using StrategyLibV1 for IStore;
 
   uint256 public constant REASSURANCE_WEIGHT_FALLBACK_VALUE = 8000;
+  uint256 public constant COVER_LAG_FALLBACK_VALUE = 1 days;
 
   enum ProductStatus {
     Normal,
@@ -161,7 +156,7 @@ library CoverUtilV1 {
       return setForTheCoverPool;
     }
 
-    // Globally set value: not set for any specifical cover
+    // Globally set value: not set for any specific cover
     uint256 setGlobally = s.getUintByKey(getReassuranceWeightKey(0));
 
     if (setGlobally > 0) {
@@ -400,7 +395,7 @@ library CoverUtilV1 {
   }
 
   /**
-   * @dev Returns the total liquidity commited/under active protection.
+   * @dev Returns the total liquidity committed/under active protection.
    * If the cover is a diversified pool, returns sum total of all products' commitments.
    *
    * Simply put, commitments are the "totalSupply" of cxTokens that haven't yet expired.
@@ -437,7 +432,7 @@ library CoverUtilV1 {
   }
 
   /**
-   * @dev Returns the total liquidity commited/under active protection.
+   * @dev Returns the total liquidity committed/under active protection.
    * If the cover is a diversified pool, you must a provide product key.
    *
    * Simply put, commitments are the "totalSupply" of cxTokens that haven't yet expired.
@@ -716,5 +711,24 @@ library CoverUtilV1 {
     bytes32 productKey
   ) public view returns (uint256) {
     return s.getUintByKeys(ProtoUtilV1.NS_GOVERNANCE_REPORTING_INCIDENT_DATE, coverKey, productKey);
+  }
+
+  function getCoverageLagInternal(IStore s, bytes32 coverKey) internal view returns (uint256) {
+    uint256 custom = s.getUintByKeys(ProtoUtilV1.NS_COVERAGE_LAG, coverKey);
+
+    // Custom means set for this exact cover
+    if (custom > 0) {
+      return custom;
+    }
+
+    // Global means set for all covers (without specifying a cover key)
+    uint256 global = s.getUintByKey(ProtoUtilV1.NS_COVERAGE_LAG);
+
+    if (global > 0) {
+      return global;
+    }
+
+    // Fallback means the default option
+    return COVER_LAG_FALLBACK_VALUE;
   }
 }

--- a/contracts/libraries/GovernanceUtilV1.sol
+++ b/contracts/libraries/GovernanceUtilV1.sol
@@ -2,6 +2,8 @@
 // Neptune Mutual Protocol (https://neptunemutual.com)
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity ^0.8.0;
+
+import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
 import "../interfaces/IStore.sol";
 import "../interfaces/IPolicy.sol";
 import "../interfaces/ICoverStake.sol";
@@ -9,17 +11,12 @@ import "../interfaces/IUnstakable.sol";
 import "../interfaces/ICoverReassurance.sol";
 import "../interfaces/IVault.sol";
 import "../interfaces/IVaultFactory.sol";
-import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
-import "./ProtoUtilV1.sol";
 import "./RoutineInvokerLibV1.sol";
-import "./StoreKeyUtil.sol";
-import "./CoverUtilV1.sol";
 
 library GovernanceUtilV1 {
   using CoverUtilV1 for IStore;
-  using StoreKeyUtil for IStore;
-  using ProtoUtilV1 for IStore;
   using RoutineInvokerLibV1 for IStore;
+  using StoreKeyUtil for IStore;
 
   /**
    * @dev Gets the reporting period for the given cover.
@@ -405,6 +402,8 @@ library GovernanceUtilV1 {
       // slither-disable-next-line divide-before-multiply
       reward = (info.totalStakeInLosingCamp * rewardRatio) / ProtoUtilV1.MULTIPLIER;
     }
+
+    require(getReportingBurnRateInternal(s) + getGovernanceReporterCommissionInternal(s) <= ProtoUtilV1.MULTIPLIER, "Invalid configuration");
 
     info.toBurn = (reward * getReportingBurnRateInternal(s)) / ProtoUtilV1.MULTIPLIER;
     info.toReporter = (reward * getGovernanceReporterCommissionInternal(s)) / ProtoUtilV1.MULTIPLIER;

--- a/contracts/libraries/PriceLibV1.sol
+++ b/contracts/libraries/PriceLibV1.sol
@@ -9,7 +9,6 @@ import "../dependencies/uniswap-v2/IUniswapV2RouterLike.sol";
 import "../dependencies/uniswap-v2/IUniswapV2PairLike.sol";
 import "../dependencies/uniswap-v2/IUniswapV2FactoryLike.sol";
 import "./ProtoUtilV1.sol";
-import "./StoreKeyUtil.sol";
 
 library PriceLibV1 {
   using ProtoUtilV1 for IStore;

--- a/contracts/libraries/RoutineInvokerLibV1.sol
+++ b/contracts/libraries/RoutineInvokerLibV1.sol
@@ -6,20 +6,15 @@ import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
 import "../interfaces/IStore.sol";
 import "../interfaces/ILendingStrategy.sol";
 import "./PriceLibV1.sol";
-import "./ProtoUtilV1.sol";
 import "./CoverUtilV1.sol";
-import "./RegistryLibV1.sol";
-import "./StrategyLibV1.sol";
-import "./ValidationLibV1.sol";
 
 library RoutineInvokerLibV1 {
+  using CoverUtilV1 for IStore;
   using PriceLibV1 for IStore;
   using ProtoUtilV1 for IStore;
   using RegistryLibV1 for IStore;
-  using StrategyLibV1 for IStore;
-  using CoverUtilV1 for IStore;
   using StoreKeyUtil for IStore;
-  using ValidationLibV1 for IStore;
+  using StrategyLibV1 for IStore;
 
   enum Action {
     Deposit,

--- a/contracts/libraries/StakingPoolCoreLibV1.sol
+++ b/contracts/libraries/StakingPoolCoreLibV1.sol
@@ -3,14 +3,13 @@
 /* solhint-disable ordering  */
 pragma solidity ^0.8.0;
 import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
-import "./StoreKeyUtil.sol";
-import "./ProtoUtilV1.sol";
-import "./NTransferUtilV2.sol";
 import "../interfaces/IStakingPools.sol";
+import "./NTransferUtilV2.sol";
+import "./StoreKeyUtil.sol";
 
 library StakingPoolCoreLibV1 {
-  using StoreKeyUtil for IStore;
   using NTransferUtilV2 for IERC20;
+  using StoreKeyUtil for IStore;
 
   bytes32 public constant NS_POOL = "ns:pool:staking";
   bytes32 public constant NS_POOL_NAME = "ns:pool:staking:name";

--- a/contracts/libraries/StakingPoolLibV1.sol
+++ b/contracts/libraries/StakingPoolLibV1.sol
@@ -3,18 +3,14 @@
 /* solhint-disable ordering  */
 pragma solidity ^0.8.0;
 import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
-import "./StoreKeyUtil.sol";
 import "./ProtoUtilV1.sol";
-import "./NTransferUtilV2.sol";
-import "./ValidationLibV1.sol";
 import "./StakingPoolCoreLibV1.sol";
 
 library StakingPoolLibV1 {
-  using ProtoUtilV1 for IStore;
-  using ValidationLibV1 for IStore;
-  using StoreKeyUtil for IStore;
-  using StakingPoolCoreLibV1 for IStore;
   using NTransferUtilV2 for IERC20;
+  using ProtoUtilV1 for IStore;
+  using StakingPoolCoreLibV1 for IStore;
+  using StoreKeyUtil for IStore;
 
   /**
    * @dev Gets the info of a given staking pool by key

--- a/contracts/libraries/StrategyLibV1.sol
+++ b/contracts/libraries/StrategyLibV1.sol
@@ -6,7 +6,6 @@ import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
 import "../interfaces/IStore.sol";
 import "../interfaces/ILendingStrategy.sol";
 import "./PriceLibV1.sol";
-import "./ProtoUtilV1.sol";
 import "./RegistryLibV1.sol";
 
 library StrategyLibV1 {

--- a/contracts/libraries/ValidationLibV1.sol
+++ b/contracts/libraries/ValidationLibV1.sol
@@ -4,22 +4,18 @@
 pragma solidity ^0.8.0;
 import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
 import "openzeppelin-solidity/contracts/access/IAccessControl.sol";
-import "./ProtoUtilV1.sol";
-import "./StoreKeyUtil.sol";
-import "./RegistryLibV1.sol";
-import "./CoverUtilV1.sol";
-import "./GovernanceUtilV1.sol";
-import "./AccessControlLibV1.sol";
 import "../interfaces/IStore.sol";
 import "../interfaces/IPausable.sol";
 import "../interfaces/ICxToken.sol";
+import "./GovernanceUtilV1.sol";
+import "./AccessControlLibV1.sol";
 
 library ValidationLibV1 {
-  using ProtoUtilV1 for IStore;
-  using StoreKeyUtil for IStore;
   using CoverUtilV1 for IStore;
   using GovernanceUtilV1 for IStore;
+  using ProtoUtilV1 for IStore;
   using RegistryLibV1 for IStore;
+  using StoreKeyUtil for IStore;
 
   /**
    * @dev Reverts if the protocol is paused
@@ -390,8 +386,8 @@ library ValidationLibV1 {
    * @dev Validates your `unstakeWithoutClaim` arguments
    *
    * @custom:note This function is not intended be used and does not produce correct result
-   * during a claim period. Please use `validateUnstakeWithClaim` if you are accessing
-   * this function during claim period.
+   * before an incident is finalized. Please use `validateUnstakeWithClaim` if you are accessing
+   * this function after resolution and before finalization.
    */
   function validateUnstakeWithoutClaim(
     IStore s,
@@ -408,9 +404,9 @@ library ValidationLibV1 {
   /**
    * @dev Validates your `unstakeWithClaim` arguments
    *
-   * @custom:note This function is only intended be used during a claim period.
+   * @custom:note This function is only intended be used after resolution and before finalization.
    * Please use `validateUnstakeWithoutClaim` if you are accessing
-   * this function after claim period expiry.
+   * this function after finalization.
    */
   function validateUnstakeWithClaim(
     IStore s,

--- a/contracts/libraries/VaultLibV1.sol
+++ b/contracts/libraries/VaultLibV1.sol
@@ -4,20 +4,14 @@
 pragma solidity ^0.8.0;
 import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
 import "openzeppelin-solidity/contracts/interfaces/IERC3156FlashLender.sol";
-import "./ProtoUtilV1.sol";
-import "./StoreKeyUtil.sol";
-import "./RegistryLibV1.sol";
-import "./CoverUtilV1.sol";
-import "./RoutineInvokerLibV1.sol";
-import "./StrategyLibV1.sol";
 import "./ValidationLibV1.sol";
 
 library VaultLibV1 {
-  using ProtoUtilV1 for IStore;
-  using StoreKeyUtil for IStore;
-  using RegistryLibV1 for IStore;
   using CoverUtilV1 for IStore;
+  using ProtoUtilV1 for IStore;
+  using RegistryLibV1 for IStore;
   using RoutineInvokerLibV1 for IStore;
+  using StoreKeyUtil for IStore;
   using StrategyLibV1 for IStore;
 
   // Before withdrawing, wait for the following number of blocks after deposit

--- a/contracts/pool/Staking/StakingPoolBase.sol
+++ b/contracts/pool/Staking/StakingPoolBase.sol
@@ -2,15 +2,10 @@
 pragma solidity ^0.8.0;
 import "../../interfaces/IStore.sol";
 import "../../interfaces/IStakingPools.sol";
-import "../../libraries/AccessControlLibV1.sol";
-import "../../libraries/ValidationLibV1.sol";
-import "../../libraries/StoreKeyUtil.sol";
-import "../../libraries/StakingPoolCoreLibV1.sol";
-import "../../libraries/StakingPoolLibV1.sol";
 import "../../core/Recoverable.sol";
+import "../../libraries/StakingPoolLibV1.sol";
 
 abstract contract StakingPoolBase is IStakingPools, Recoverable {
-  using AccessControlLibV1 for IStore;
   using ValidationLibV1 for IStore;
   using StoreKeyUtil for IStore;
   using StakingPoolCoreLibV1 for IStore;

--- a/contracts/pool/Staking/StakingPoolInfo.sol
+++ b/contracts/pool/Staking/StakingPoolInfo.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.0;
 import "./StakingPoolReward.sol";
 
 abstract contract StakingPoolInfo is StakingPoolReward {
-  using StakingPoolCoreLibV1 for IStore;
   using StakingPoolLibV1 for IStore;
 
   constructor(IStore s) StakingPoolReward(s) {} //solhint-disable-line

--- a/contracts/pool/Staking/StakingPools.sol
+++ b/contracts/pool/Staking/StakingPools.sol
@@ -4,7 +4,6 @@ import "./StakingPoolInfo.sol";
 
 contract StakingPools is StakingPoolInfo {
   using ValidationLibV1 for IStore;
-  using StoreKeyUtil for IStore;
   using StakingPoolCoreLibV1 for IStore;
   using StakingPoolLibV1 for IStore;
 

--- a/examples/dedicated/exchanges/binance.js
+++ b/examples/dedicated/exchanges/binance.js
@@ -11,8 +11,8 @@ module.exports = {
   tokenName: 'Income Bearing DAI',
   tokenSymbol: 'iDAI-BNB',
   requiresWhitelist: false,
-  supportsProducts: true,
-  leverageFactor: '10',
+  supportsProducts: false,
+  leverageFactor: '1',
   tags: ['exchange', 'cex', 'bnb', 'binance'],
   about: 'Founded in 2017 Binance is by far the largest centralized crypto exchange ranked by daily volume traded. Users can trade spots, futures and derivatives via its online platform and mobile app. Centralized exchanges operate order books and take custody of users assets to facilitate trading, it also facilitates lending and borrowing as well as other services such as staking to its user base.',
   parameters: [

--- a/examples/dedicated/exchanges/coinbase.js
+++ b/examples/dedicated/exchanges/coinbase.js
@@ -11,8 +11,8 @@ module.exports = {
   tokenName: 'Income Bearing DAI',
   tokenSymbol: 'iDAI-COIN',
   requiresWhitelist: false,
-  supportsProducts: true,
-  leverageFactor: '10',
+  supportsProducts: false,
+  leverageFactor: '1',
   tags: ['exchange', 'cex', 'coinbase', 'coin'],
   about: 'Founded in 2012 Coinbase is the largest exchange for institutional crypto traders, and the first crypto exchange that went public and listed on Nasdaq. Users can trade mainly spots via its online platform and mobile app. Centralized exchanges operate order books and take custody of users assets to facilitate trading, it also facilitates lending and borrowing as well as other services such as staking to its user base.',
   parameters: [

--- a/examples/dedicated/exchanges/huobi.js
+++ b/examples/dedicated/exchanges/huobi.js
@@ -11,8 +11,8 @@ module.exports = {
   tokenName: 'Income Bearing DAI',
   tokenSymbol: 'iDAI-HT',
   requiresWhitelist: false,
-  supportsProducts: true,
-  leverageFactor: '10',
+  supportsProducts: false,
+  leverageFactor: '1',
   tags: ['exchange', 'cex', 'huobi', 'ht'],
   about: 'Founded in 2013 Huobi Global is amongst the battle tested crypto exchanges with longer operating history and once ranked number 1 globally in terms of trading volume. Users can trade spots, futures and derivatives via its online platform and mobile app. Centralized exchanges operate order books and take custody of users assets to facilitate trading, it also facilitates lending and borrowing as well as other services such as staking to its user base.',
   parameters: [

--- a/examples/dedicated/exchanges/okx.js
+++ b/examples/dedicated/exchanges/okx.js
@@ -11,8 +11,8 @@ module.exports = {
   tokenName: 'Income Bearing DAI',
   tokenSymbol: 'iDAI-OKX',
   requiresWhitelist: false,
-  supportsProducts: true,
-  leverageFactor: '10',
+  supportsProducts: false,
+  leverageFactor: '1',
   tags: ['exchange', 'cex', 'okx', 'okex'],
   about: 'Founded in 2017, OKX is a rebrand from the former OKEX exchange, it is one of the leading global crypto exchanges,  particularly with strong derivatives trading volume. Users can trade spots, futures and derivatives via its online platform and mobile app. Centralized exchanges operate order books and take custody of users assets to facilitate trading, it also facilitates lending and borrowing as well as other services such as staking to its user base.',
   parameters: [

--- a/examples/diversified/defi/products/uniswap.js
+++ b/examples/diversified/defi/products/uniswap.js
@@ -4,7 +4,7 @@ const cover = require('../cover')
 module.exports = {
   coverKey: cover.coverKey,
   productKey: key.toBytes32('uniswap-v3'),
-  productName: 'Uniswap (v3)',
+  productName: 'Uniswap v3',
   requiresWhitelist: false,
   efficiency: helper.percentage(90),
   tags: ['exchange', 'dex', 'swap', 'flashloan', 'nft'],

--- a/examples/diversified/prime/products/uniswap.js
+++ b/examples/diversified/prime/products/uniswap.js
@@ -4,7 +4,7 @@ const cover = require('../cover')
 module.exports = {
   coverKey: cover.coverKey,
   productKey: key.toBytes32('uniswap-v2'),
-  productName: 'Uniswap V2',
+  productName: 'Uniswap v2',
   requiresWhitelist: false,
   efficiency: helper.percentage(90),
   tags: ['exchange', 'dex', 'swap', 'nft'],

--- a/oracle/contracts/IPriceOracle.sol
+++ b/oracle/contracts/IPriceOracle.sol
@@ -1,5 +1,6 @@
 // Neptune Mutual Protocol (https://neptunemutual.com)
 // SPDX-License-Identifier: BUSL-1.1
+// solhint-disable compiler-version
 pragma solidity 0.6.6;
 
 interface IPriceOracle {

--- a/oracle/contracts/NpmPriceOracle.sol
+++ b/oracle/contracts/NpmPriceOracle.sol
@@ -1,5 +1,6 @@
 // Neptune Mutual Protocol (https://neptunemutual.com)
 // SPDX-License-Identifier: GPL-3.0
+// solhint-disable compiler-version
 pragma solidity 0.6.6;
 
 import "@uniswap/v2-core/contracts/interfaces/IUniswapV2Factory.sol";

--- a/oracle/package.json
+++ b/oracle/package.json
@@ -49,5 +49,9 @@
     "solidity-coverage": "^0.7.17",
     "standard": "^16.0.4",
     "openzeppelin-solidity": "3.4.0"
+  },
+  "volta": {
+    "node": "16.13.1",
+    "yarn": "1.22.19"
   }
 }

--- a/test/examples/distributor/deps.js
+++ b/test/examples/distributor/deps.js
@@ -141,7 +141,9 @@ const deployDependencies = async () => {
 
   await protocol.initialize(args)
 
-  await protocol.grantRoles([{ account: owner.address, roles: [key.ACCESS_CONTROL.UPGRADE_AGENT, key.ACCESS_CONTROL.COVER_MANAGER, key.ACCESS_CONTROL.GOVERNANCE_AGENT, key.ACCESS_CONTROL.LIQUIDITY_MANAGER, key.ACCESS_CONTROL.PAUSE_AGENT, key.ACCESS_CONTROL.UNPAUSE_AGENT] }])
+  await protocol.grantRoles([{ account: owner.address, roles: [key.ACCESS_CONTROL.UPGRADE_AGENT, key.ACCESS_CONTROL.COVER_MANAGER, key.ACCESS_CONTROL.LIQUIDITY_MANAGER, key.ACCESS_CONTROL.PAUSE_AGENT, key.ACCESS_CONTROL.UNPAUSE_AGENT, key.ACCESS_CONTROL.GOVERNANCE_ADMIN] }])
+  await protocol.grantRoles([{ account: owner.address, roles: [key.ACCESS_CONTROL.GOVERNANCE_AGENT] }])
+
   await protocol.grantRole(key.ACCESS_CONTROL.UPGRADE_AGENT, protocol.address)
 
   const cover = await deployer.deployWithLibraries(cache, 'Cover',
@@ -379,6 +381,7 @@ const deployDependencies = async () => {
 
   await dai.approve(vault.address, initialLiquidity)
   await npm.approve(vault.address, minStakeToReport)
+
   await vault.addLiquidity({
     coverKey,
     amount: initialLiquidity,

--- a/test/examples/distributor/remove-liquidity.spec.js
+++ b/test/examples/distributor/remove-liquidity.spec.js
@@ -31,6 +31,8 @@ describe('Distributor: `removeLiquidity` function', () => {
     await deployed.npm.approve(distributor.address, ethers.constants.MaxUint256)
     await deployed.dai.approve(distributor.address, ethers.constants.MaxUint256)
 
+    await deployed.cover.setMinStakeToAddLiquidity(helper.ether(250))
+
     await distributor.addLiquidity({
       coverKey,
       amount,

--- a/test/specs/cx-token-factory/deps.js
+++ b/test/specs/cx-token-factory/deps.js
@@ -139,7 +139,9 @@ const deployDependencies = async () => {
 
   await protocol.initialize(args)
 
-  await protocol.grantRoles([{ account: owner.address, roles: [key.ACCESS_CONTROL.UPGRADE_AGENT, key.ACCESS_CONTROL.COVER_MANAGER, key.ACCESS_CONTROL.GOVERNANCE_AGENT, key.ACCESS_CONTROL.LIQUIDITY_MANAGER, key.ACCESS_CONTROL.PAUSE_AGENT, key.ACCESS_CONTROL.UNPAUSE_AGENT] }])
+  await protocol.grantRoles([{ account: owner.address, roles: [key.ACCESS_CONTROL.UPGRADE_AGENT, key.ACCESS_CONTROL.COVER_MANAGER, key.ACCESS_CONTROL.GOVERNANCE_ADMIN, key.ACCESS_CONTROL.LIQUIDITY_MANAGER, key.ACCESS_CONTROL.PAUSE_AGENT, key.ACCESS_CONTROL.UNPAUSE_AGENT] }])
+  await protocol.grantRoles([{ account: owner.address, roles: [key.ACCESS_CONTROL.GOVERNANCE_AGENT] }])
+
   await protocol.grantRole(key.ACCESS_CONTROL.UPGRADE_AGENT, protocol.address)
 
   const cover = await deployer.deployWithLibraries(cache, 'Cover',

--- a/test/specs/cx-token/deps.js
+++ b/test/specs/cx-token/deps.js
@@ -149,11 +149,13 @@ const deployDependencies = async () => {
         key.ACCESS_CONTROL.LIQUIDITY_MANAGER,
         key.ACCESS_CONTROL.PAUSE_AGENT,
         key.ACCESS_CONTROL.GOVERNANCE_ADMIN,
-        key.ACCESS_CONTROL.GOVERNANCE_AGENT,
         key.ACCESS_CONTROL.UNPAUSE_AGENT
       ]
     }
   ])
+
+  await protocol.grantRoles([{ account: owner.address, roles: [key.ACCESS_CONTROL.GOVERNANCE_AGENT] }])
+
   await protocol.grantRole(key.ACCESS_CONTROL.UPGRADE_AGENT, protocol.address)
 
   const cover = await deployer.deployWithLibraries(cache, 'Cover',

--- a/test/specs/governance/deps.js
+++ b/test/specs/governance/deps.js
@@ -156,11 +156,13 @@ const deployDependencies = async () => {
     roles: [key.ACCESS_CONTROL.UPGRADE_AGENT,
       key.ACCESS_CONTROL.COVER_MANAGER,
       key.ACCESS_CONTROL.LIQUIDITY_MANAGER,
-      key.ACCESS_CONTROL.GOVERNANCE_AGENT,
       key.ACCESS_CONTROL.GOVERNANCE_ADMIN,
       key.ACCESS_CONTROL.PAUSE_AGENT,
       key.ACCESS_CONTROL.UNPAUSE_AGENT]
   }])
+
+  await protocol.grantRoles([{ account: owner.address, roles: [key.ACCESS_CONTROL.GOVERNANCE_AGENT] }])
+
   await protocol.grantRole(key.ACCESS_CONTROL.UPGRADE_AGENT, protocol.address)
 
   const cover = await deployer.deployWithLibraries(cache, 'Cover',

--- a/test/specs/governance/resolution/deps.js
+++ b/test/specs/governance/resolution/deps.js
@@ -146,10 +146,11 @@ const deployDependencies = async () => {
       key.ACCESS_CONTROL.COVER_MANAGER,
       key.ACCESS_CONTROL.LIQUIDITY_MANAGER,
       key.ACCESS_CONTROL.PAUSE_AGENT,
-      key.ACCESS_CONTROL.GOVERNANCE_AGENT,
       key.ACCESS_CONTROL.GOVERNANCE_ADMIN,
       key.ACCESS_CONTROL.UNPAUSE_AGENT]
   }])
+
+  await protocol.grantRole(key.ACCESS_CONTROL.GOVERNANCE_AGENT, owner.address)
   await protocol.grantRole(key.ACCESS_CONTROL.UPGRADE_AGENT, protocol.address)
 
   const cover = await deployer.deployWithLibraries(cache, 'Cover',

--- a/test/specs/libraries/deps.js
+++ b/test/specs/libraries/deps.js
@@ -157,12 +157,13 @@ const deployDependencies = async () => {
     roles: [key.ACCESS_CONTROL.UPGRADE_AGENT,
       key.ACCESS_CONTROL.COVER_MANAGER,
       key.ACCESS_CONTROL.LIQUIDITY_MANAGER,
-      key.ACCESS_CONTROL.GOVERNANCE_AGENT,
       key.ACCESS_CONTROL.GOVERNANCE_ADMIN,
       key.ACCESS_CONTROL.RECOVERY_AGENT,
       key.ACCESS_CONTROL.PAUSE_AGENT,
       key.ACCESS_CONTROL.UNPAUSE_AGENT]
   }])
+
+  await protocol.grantRoles([{ account: owner.address, roles: [key.ACCESS_CONTROL.GOVERNANCE_AGENT] }])
   await protocol.grantRole(key.ACCESS_CONTROL.UPGRADE_AGENT, protocol.address)
 
   const cover = await deployer.deployWithLibraries(cache, 'Cover',

--- a/test/specs/libraries/vault.spec.js
+++ b/test/specs/libraries/vault.spec.js
@@ -38,6 +38,8 @@ describe('Vault Library', () => {
     await deployed.npm.approve(deployed.cover.address, stakeWithFee)
     await deployed.dai.approve(deployed.cover.address, initialReassuranceAmount)
 
+    await deployed.cover.setMinStakeToAddLiquidity(helper.ether(250))
+
     await deployed.cover.addCover({
       coverKey,
       info,

--- a/test/specs/lifecycle/cover-reassurance/deps.js
+++ b/test/specs/lifecycle/cover-reassurance/deps.js
@@ -149,11 +149,12 @@ const deployDependencies = async () => {
         key.ACCESS_CONTROL.LIQUIDITY_MANAGER,
         key.ACCESS_CONTROL.PAUSE_AGENT,
         key.ACCESS_CONTROL.GOVERNANCE_ADMIN,
-        key.ACCESS_CONTROL.GOVERNANCE_AGENT,
         key.ACCESS_CONTROL.UNPAUSE_AGENT
       ]
     }
   ])
+
+  await protocol.grantRoles([{ account: owner.address, roles: [key.ACCESS_CONTROL.GOVERNANCE_AGENT] }])
   await protocol.grantRole(key.ACCESS_CONTROL.UPGRADE_AGENT, protocol.address)
 
   const cover = await deployer.deployWithLibraries(cache, 'Cover',

--- a/test/specs/lifecycle/cover-stake/deps.js
+++ b/test/specs/lifecycle/cover-stake/deps.js
@@ -149,11 +149,12 @@ const deployDependencies = async () => {
         key.ACCESS_CONTROL.LIQUIDITY_MANAGER,
         key.ACCESS_CONTROL.PAUSE_AGENT,
         key.ACCESS_CONTROL.GOVERNANCE_ADMIN,
-        key.ACCESS_CONTROL.GOVERNANCE_AGENT,
         key.ACCESS_CONTROL.UNPAUSE_AGENT
       ]
     }
   ])
+
+  await protocol.grantRoles([{ account: owner.address, roles: [key.ACCESS_CONTROL.GOVERNANCE_AGENT] }])
   await protocol.grantRole(key.ACCESS_CONTROL.UPGRADE_AGENT, protocol.address)
 
   const cover = await deployer.deployWithLibraries(cache, 'Cover',

--- a/test/specs/lifecycle/cover/deps.js
+++ b/test/specs/lifecycle/cover/deps.js
@@ -151,11 +151,12 @@ const deployDependencies = async () => {
         key.ACCESS_CONTROL.LIQUIDITY_MANAGER,
         key.ACCESS_CONTROL.PAUSE_AGENT,
         key.ACCESS_CONTROL.GOVERNANCE_ADMIN,
-        key.ACCESS_CONTROL.GOVERNANCE_AGENT,
         key.ACCESS_CONTROL.UNPAUSE_AGENT
       ]
     }
   ])
+
+  await protocol.grantRoles([{ account: owner.address, roles: [key.ACCESS_CONTROL.GOVERNANCE_AGENT] }])
   await protocol.grantRole(key.ACCESS_CONTROL.UPGRADE_AGENT, protocol.address)
 
   const cover = await deployer.deployWithLibraries(cache, 'Cover',

--- a/test/specs/lifecycle/cover/set-min-stake-to-add-liquidity.spec.js
+++ b/test/specs/lifecycle/cover/set-min-stake-to-add-liquidity.spec.js
@@ -22,7 +22,7 @@ describe('Cover: setMinStakeToAddLiquidity', () => {
     const { events } = await tx.wait()
 
     const event = events.find(x => x.event === 'MinStakeToAddLiquiditySet')
-    event.args.previous.should.equal(helper.ether(250))
+    event.args.previous.should.equal(helper.ether(0))
     event.args.current.should.equal(minStake)
   })
 

--- a/test/specs/liquidity/delegates/deps.js
+++ b/test/specs/liquidity/delegates/deps.js
@@ -161,11 +161,12 @@ const deployDependencies = async () => {
     roles: [key.ACCESS_CONTROL.UPGRADE_AGENT,
       key.ACCESS_CONTROL.COVER_MANAGER,
       key.ACCESS_CONTROL.LIQUIDITY_MANAGER,
-      key.ACCESS_CONTROL.GOVERNANCE_AGENT,
       key.ACCESS_CONTROL.GOVERNANCE_ADMIN,
       key.ACCESS_CONTROL.PAUSE_AGENT,
       key.ACCESS_CONTROL.UNPAUSE_AGENT]
   }])
+
+  await protocol.grantRoles([{ account: owner.address, roles: [key.ACCESS_CONTROL.GOVERNANCE_AGENT] }])
   await protocol.grantRole(key.ACCESS_CONTROL.UPGRADE_AGENT, protocol.address)
 
   const cover = await deployer.deployWithLibraries(cache, 'Cover',

--- a/test/specs/liquidity/strategy/aave/ctor.spec.js
+++ b/test/specs/liquidity/strategy/aave/ctor.spec.js
@@ -3,6 +3,7 @@ const BigNumber = require('bignumber.js')
 const { deployer, key, helper } = require('../../../../../util')
 const { deployDependencies } = require('../deps')
 const cache = null
+const CNAME_STRATEGY_AAVE = key.toBytes32('Aave Strategy')
 
 require('chai')
   .use(require('chai-as-promised'))
@@ -32,6 +33,6 @@ describe('Aave Strategy Constructor', () => {
 
    ; (await aaveStrategy.getKey()).should.equal(ethers.utils.solidityKeccak256(['string', 'string', 'string', 'string'], ['lending', 'strategy', 'aave', 'v2']))
     ; (await aaveStrategy.version()).should.equal(key.toBytes32('v0.1'))
-    ; (await aaveStrategy.getName()).should.equal(key.PROTOCOL.CNAME.STRATEGY_AAVE)
+    ; (await aaveStrategy.getName()).should.equal(CNAME_STRATEGY_AAVE)
   })
 })

--- a/test/specs/liquidity/strategy/compound/ctor.spec.js
+++ b/test/specs/liquidity/strategy/compound/ctor.spec.js
@@ -3,6 +3,7 @@ const BigNumber = require('bignumber.js')
 const { deployer, key, helper } = require('../../../../../util')
 const { deployDependencies } = require('../deps')
 const cache = null
+const CNAME_STRATEGY_COMPOUND = key.toBytes32('Compound Strategy')
 
 require('chai')
   .use(require('chai-as-promised'))
@@ -32,6 +33,6 @@ describe('Compound Strategy Constructor', () => {
 
    ; (await compoundStrategy.getKey()).should.equal(ethers.utils.solidityKeccak256(['string', 'string', 'string', 'string'], ['lending', 'strategy', 'compound', 'v2']))
     ; (await compoundStrategy.version()).should.equal(key.toBytes32('v0.1'))
-    ; (await compoundStrategy.getName()).should.equal(key.PROTOCOL.CNAME.STRATEGY_COMPOUND)
+    ; (await compoundStrategy.getName()).should.equal(CNAME_STRATEGY_COMPOUND)
   })
 })

--- a/test/specs/liquidity/strategy/deps.js
+++ b/test/specs/liquidity/strategy/deps.js
@@ -140,7 +140,9 @@ const deployDependencies = async () => {
 
   await protocol.initialize(args)
 
-  await protocol.grantRoles([{ account: owner.address, roles: [key.ACCESS_CONTROL.UPGRADE_AGENT, key.ACCESS_CONTROL.COVER_MANAGER, key.ACCESS_CONTROL.GOVERNANCE_AGENT, key.ACCESS_CONTROL.LIQUIDITY_MANAGER, key.ACCESS_CONTROL.PAUSE_AGENT, key.ACCESS_CONTROL.UNPAUSE_AGENT] }])
+  await protocol.grantRoles([{ account: owner.address, roles: [key.ACCESS_CONTROL.UPGRADE_AGENT, key.ACCESS_CONTROL.COVER_MANAGER, key.ACCESS_CONTROL.GOVERNANCE_ADMIN, key.ACCESS_CONTROL.LIQUIDITY_MANAGER, key.ACCESS_CONTROL.PAUSE_AGENT, key.ACCESS_CONTROL.UNPAUSE_AGENT] }])
+
+  await protocol.grantRoles([{ account: owner.address, roles: [key.ACCESS_CONTROL.GOVERNANCE_AGENT] }])
   await protocol.grantRole(key.ACCESS_CONTROL.UPGRADE_AGENT, protocol.address)
 
   const cover = await deployer.deployWithLibraries(cache, 'Cover',

--- a/test/specs/liquidity/vault/deps.js
+++ b/test/specs/liquidity/vault/deps.js
@@ -144,7 +144,9 @@ const deployDependencies = async () => {
 
   await protocol.initialize(args)
 
-  await protocol.grantRoles([{ account: owner.address, roles: [key.ACCESS_CONTROL.UPGRADE_AGENT, key.ACCESS_CONTROL.COVER_MANAGER, key.ACCESS_CONTROL.LIQUIDITY_MANAGER, key.ACCESS_CONTROL.GOVERNANCE_AGENT, key.ACCESS_CONTROL.PAUSE_AGENT, key.ACCESS_CONTROL.UNPAUSE_AGENT, key.ACCESS_CONTROL.GOVERNANCE_ADMIN] }])
+  await protocol.grantRoles([{ account: owner.address, roles: [key.ACCESS_CONTROL.UPGRADE_AGENT, key.ACCESS_CONTROL.COVER_MANAGER, key.ACCESS_CONTROL.LIQUIDITY_MANAGER, key.ACCESS_CONTROL.GOVERNANCE_ADMIN, key.ACCESS_CONTROL.PAUSE_AGENT, key.ACCESS_CONTROL.UNPAUSE_AGENT] }])
+
+  await protocol.grantRoles([{ account: owner.address, roles: [key.ACCESS_CONTROL.GOVERNANCE_AGENT] }])
   await protocol.grantRole(key.ACCESS_CONTROL.UPGRADE_AGENT, protocol.address)
 
   const cover = await deployer.deployWithLibraries(cache, 'Cover',

--- a/test/specs/policy-admin/deps.js
+++ b/test/specs/policy-admin/deps.js
@@ -148,7 +148,7 @@ const deployDependencies = async () => {
 
   await protocol.initialize(args)
 
-  await protocol.grantRoles([{ account: owner.address, roles: [key.ACCESS_CONTROL.UPGRADE_AGENT, key.ACCESS_CONTROL.COVER_MANAGER, key.ACCESS_CONTROL.LIQUIDITY_MANAGER, key.ACCESS_CONTROL.GOVERNANCE_AGENT, key.ACCESS_CONTROL.PAUSE_AGENT, key.ACCESS_CONTROL.UNPAUSE_AGENT] }])
+  await protocol.grantRoles([{ account: owner.address, roles: [key.ACCESS_CONTROL.UPGRADE_AGENT, key.ACCESS_CONTROL.COVER_MANAGER, key.ACCESS_CONTROL.LIQUIDITY_MANAGER, key.ACCESS_CONTROL.GOVERNANCE_ADMIN, key.ACCESS_CONTROL.PAUSE_AGENT, key.ACCESS_CONTROL.UNPAUSE_AGENT] }])
   await protocol.grantRole(key.ACCESS_CONTROL.UPGRADE_AGENT, protocol.address)
 
   const cover = await deployer.deployWithLibraries(cache, 'Cover',

--- a/test/specs/policy-admin/set-coverage-lag.spec.js
+++ b/test/specs/policy-admin/set-coverage-lag.spec.js
@@ -62,7 +62,7 @@ describe('Policy Admin: setCoverageLag', () => {
     const before = await deployed.policyAdminContract.getCoverageLag(coverKey)
     before.should.equal(1 * DAYS)
 
-    const window = 2 * DAYS
+    const window = 1 * DAYS
 
     // Sets the global coverage lag, when coverKey is 0
     const tx = await deployed.policyAdminContract.setCoverageLag(key.toBytes32(''), window)
@@ -78,7 +78,7 @@ describe('Policy Admin: setCoverageLag', () => {
   })
 
   it('succeeds without any errors', async () => {
-    const window = 2 * DAYS
+    const window = 1 * DAYS
 
     const tx = await deployed.policyAdminContract.setCoverageLag(coverKey, window)
     const { events } = await tx.wait()

--- a/test/specs/policy/deps.js
+++ b/test/specs/policy/deps.js
@@ -139,7 +139,8 @@ const deployDependencies = async () => {
   }
   await protocol.initialize(args)
 
-  await protocol.grantRoles([{ account: owner.address, roles: [key.ACCESS_CONTROL.UPGRADE_AGENT, key.ACCESS_CONTROL.COVER_MANAGER, key.ACCESS_CONTROL.GOVERNANCE_AGENT, key.ACCESS_CONTROL.LIQUIDITY_MANAGER, key.ACCESS_CONTROL.PAUSE_AGENT, key.ACCESS_CONTROL.UNPAUSE_AGENT, key.ACCESS_CONTROL.GOVERNANCE_ADMIN] }])
+  await protocol.grantRoles([{ account: owner.address, roles: [key.ACCESS_CONTROL.UPGRADE_AGENT, key.ACCESS_CONTROL.COVER_MANAGER, key.ACCESS_CONTROL.LIQUIDITY_MANAGER, key.ACCESS_CONTROL.PAUSE_AGENT, key.ACCESS_CONTROL.UNPAUSE_AGENT, key.ACCESS_CONTROL.GOVERNANCE_ADMIN] }])
+  await protocol.grantRoles([{ account: owner.address, roles: [key.ACCESS_CONTROL.GOVERNANCE_AGENT] }])
   await protocol.grantRole(key.ACCESS_CONTROL.UPGRADE_AGENT, protocol.address)
 
   const cover = await deployer.deployWithLibraries(cache, 'Cover',

--- a/test/specs/protocol/grant-role.spec.js
+++ b/test/specs/protocol/grant-role.spec.js
@@ -95,6 +95,7 @@ describe('Grant roles in protocol', () => {
     const [owner,, charles] = await ethers.getSigners()
 
     const hasRole = await protocol.hasRole(key.ACCESS_CONTROL.GOVERNANCE_ADMIN, owner.address)
+
     await protocol.grantRole(key.ACCESS_CONTROL.GOVERNANCE_AGENT, charles.address)
       .should.be.rejectedWith(`AccessControl: account ${owner.address.toLowerCase()} is missing role ${key.ACCESS_CONTROL.GOVERNANCE_ADMIN}`)
 

--- a/test/stories/5.coverage.claim.spec.js
+++ b/test/stories/5.coverage.claim.spec.js
@@ -169,6 +169,7 @@ describe('Coverage Claim Stories', function () {
     await contracts.npm.approve(contracts.governance.address, helper.ether(100_000))
     await contracts.governance.report(coverKey, helper.emptyBytes32, info, helper.ether(100_000))
 
+    await contracts.protocol.grantRole(key.ACCESS_CONTROL.GOVERNANCE_ADMIN, owner.address)
     await contracts.protocol.grantRole(key.ACCESS_CONTROL.GOVERNANCE_AGENT, owner.address)
 
     const incidentDate = await contracts.governance.getActiveIncidentDate(coverKey, helper.emptyBytes32)


### PR DESCRIPTION
- [OZ M-03] Refactored `cxToken.mint` and `PolicyHelperV1.calculatePolicyFeeInternal` function to rectify the erroneous update to the logic for determining the `effectiveFrom` timestamp
- [OZ M-04] Refactored protocol contract to remove parallel access control
- [OZ M-05] Fixed inaccurate `unstakeWithClaim` comments on `Resolution contract documentation` and `validateUnstakeWithClaim` function
- [OZ L-03] Refactored `_getExcludedCoverageOf` function to include the resolution EOD timestamp
- [OZ L-03] Added validation to the `_addCover` function to verify that reporting period is greater than or equal to coverage lag.
- [OZ L-06] Added validations to the following functions to ensure the total of `reporting burn rate` and `reporter commission` is less than or equal to the multiplier: `Protocol.initialize`, `setReportingBurnRate`, `setReporterCommission`, and `getUnstakeInfoForInternal`
- [OZ N-16] Fixed typographical errors
- [OZ N-20] Dropped unused imports

## Other Fixes:

- Corrected an error in the documentation of the `unstake` and `validateUnstakeWithoutClaim` functions.
 - Corrected an error in the dedicated pool examples (supportsProduct and leverageFactor).
- Pinned node and yarn versions
- Fixed tests